### PR TITLE
Fix akka pod discovery

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 - Clean and improve repository structure [#13](https://github.com/StrangeBeeCorp/helm-charts/pull/13)
 - Fix Cassandra OOM crashloop [#14](https://github.com/StrangeBeeCorp/helm-charts/pull/14)
+- Fix akka pod discovery [#15](https://github.com/StrangeBeeCorp/helm-charts/pull/15)

--- a/charts/thehive/templates/_helpers.tpl
+++ b/charts/thehive/templates/_helpers.tpl
@@ -30,24 +30,53 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
-{{- define "thehive.labels" -}}
-helm.sh/chart: {{ include "thehive.chart" . }}
-{{ include "thehive.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+{{/* Common labels */}}
+{{- define "thehive.commonLabels" -}}
+app.kubernetes.io/part-of: "TheHive"
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
+{{/* TheHive selector labels */}}
 {{- define "thehive.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "thehive.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* TheHive labels */}}
+{{- define "thehive.labels" -}}
+{{ include "thehive.commonLabels" . }}
+{{ include "thehive.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion }}
+app.kubernetes.io/component: "frontend"
+{{- end }}
+
+{{/* Cassandra selector labels */}}
+{{- define "thehive.cassandra.selectorLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-cassandra" (include "thehive.name" .) }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Cassandra labels */}}
+{{- define "thehive.cassandra.labels" -}}
+{{ include "thehive.commonLabels" . }}
+{{ include "thehive.cassandra.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.cassandra.version }}
+app.kubernetes.io/component: "database"
+{{- end }}
+
+{{/* MinIO selector labels */}}
+{{- define "thehive.minio.selectorLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-minio" (include "thehive.name" .) }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* MinIO labels */}}
+{{- define "thehive.minio.labels" -}}
+{{ include "thehive.commonLabels" . }}
+{{ include "thehive.minio.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.minio.image.tag }}
+app.kubernetes.io/component: "file-storage"
 {{- end }}
 
 {{/*
@@ -60,24 +89,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{/*
-Selector Minio labels
-*/}}
-{{- define "thehive.minioSelectorLabels" -}}
-app.kubernetes.io/name: {{ printf "%s-minio" .Release.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Minio labels
-*/}}
-{{- define "thehive.minioLabels" -}}
-helm.sh/chart: {{ include "thehive.chart" . }}
-{{ include "thehive.minioSelectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-

--- a/charts/thehive/templates/_helpers.tpl
+++ b/charts/thehive/templates/_helpers.tpl
@@ -47,7 +47,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "thehive.labels" -}}
 {{ include "thehive.commonLabels" . }}
 {{ include "thehive.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/component: "frontend"
 {{- end }}
 
@@ -61,7 +61,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "thehive.cassandra.labels" -}}
 {{ include "thehive.commonLabels" . }}
 {{ include "thehive.cassandra.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.cassandra.version }}
+app.kubernetes.io/version: {{ .Values.cassandra.version | quote }}
 app.kubernetes.io/component: "database"
 {{- end }}
 
@@ -75,7 +75,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "thehive.minio.labels" -}}
 {{ include "thehive.commonLabels" . }}
 {{ include "thehive.minio.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.minio.image.tag }}
+app.kubernetes.io/version: {{ .Values.minio.image.tag | quote }}
 app.kubernetes.io/component: "file-storage"
 {{- end }}
 

--- a/charts/thehive/templates/database/service.yaml
+++ b/charts/thehive/templates/database/service.yaml
@@ -3,12 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: thehive-cassandra
-    {{- include "thehive.labels" . | nindent 4 }}
+    {{- include "thehive.cassandra.labels" . | nindent 4 }}
   name: {{ include "thehive.fullname" . }}-cassandra
 spec:
   ports:
     - port: 9042
   selector:
-    app: thehive-cassandra
+    {{- include "thehive.cassandra.selectorLabels" . | nindent 4 }}
 {{- end}}

--- a/charts/thehive/templates/database/statefulset.yaml
+++ b/charts/thehive/templates/database/statefulset.yaml
@@ -4,8 +4,7 @@ kind: StatefulSet
 metadata:
   name: {{ include "thehive.fullname" . }}-cassandra
   labels:
-    app: thehive-cassandra
-    {{- include "thehive.labels" . | nindent 4 }}
+    {{- include "thehive.cassandra.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "thehive.fullname" . }}-cassandra
   {{- if .Values.cassandra.persistence.enabled }}
@@ -23,12 +22,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: thehive-cassandra
+      {{- include "thehive.cassandra.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: thehive-cassandra
-        {{- include "thehive.labels" . | nindent 8 }}
+        {{- include "thehive.cassandra.labels" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 1800
       containers:

--- a/charts/thehive/templates/minio/pod.yaml
+++ b/charts/thehive/templates/minio/pod.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: thehive-minio-create-bucket
+  labels:
+    {{ include "thehive.commonLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation

--- a/charts/thehive/templates/minio/service.yaml
+++ b/charts/thehive/templates/minio/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ include  "thehive.fullname" . }}-minio
   labels:
-    {{ include "thehive.minioLabels" . | nindent 4 }}
+    {{ include "thehive.minio.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-1"
@@ -14,5 +14,5 @@ spec:
       targetPort: 9000
       protocol: TCP
   selector:
-    {{ include "thehive.minioSelectorLabels" . | nindent 4 }}
+    {{ include "thehive.minio.selectorLabels" . | nindent 4 }}
 {{ end }}

--- a/charts/thehive/templates/minio/sts.yaml
+++ b/charts/thehive/templates/minio/sts.yaml
@@ -8,11 +8,11 @@ metadata:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-1"
   labels:
-    {{ include "thehive.minioLabels" . | nindent 4 }}
+    {{ include "thehive.minio.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{ include "thehive.minioSelectorLabels" . | nindent 6 }}
+      {{ include "thehive.minio.selectorLabels" . | nindent 6 }}
   serviceName: thehive-minio-svc
   volumeClaimTemplates:
       - metadata:
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         # Label is used as selector in the service.
-        {{ include "thehive.minioSelectorLabels" . | nindent 8 }}
+        {{ include "thehive.minio.labels" . | nindent 8 }}
     spec:
       # Refer to the PVC created earlier
       containers:

--- a/charts/thehive/templates/pdb.yaml
+++ b/charts/thehive/templates/pdb.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thehive.fullname" . }}
+  labels:
+    {{- include "thehive.labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.thehive.maxUnavailable | default 1 }}
   selector:

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -127,7 +127,7 @@ thehive:
   # -- TheHive Secret
   secret: "SuperSecretForKubernetes"
   # -- TheHive Nodes count
-  clusterMinNodesCount: 0
+  clusterMinNodesCount: 1
   # -- Cortex configuration
   cortex:
     enabled: false


### PR DESCRIPTION
### Issue identified

Both TheHive and Cassandra deployments shared the same labels.

On TheHive application start, akka was discovering both TheHive and Cassandra pods, but the latter weren't responding to requests. This caused errors in akka's side and TheHive pods to crash.


### Changes summary

- Improve labels definition for TheHive, Cassandra and MinIO in `_helpers.tpl`
- Create a dedicated set of labels for Cassandra
- Add missing TheHive labels in PodDisruptionBudget manifest
- Set TheHive's `clusterMinNodesCount` to its default value of `1`