### PR TITLE
Update and pin images versions

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Clean and improve repository structure [#13](https://github.com/StrangeBeeCorp/helm-charts/pull/13)
 - Fix Cassandra OOM crashloop [#14](https://github.com/StrangeBeeCorp/helm-charts/pull/14)
 - Fix akka pod discovery [#15](https://github.com/StrangeBeeCorp/helm-charts/pull/15)
+- Update and pin images versions [#16](https://github.com/StrangeBeeCorp/helm-charts/pull/16)

--- a/charts/thehive/Chart.yaml
+++ b/charts/thehive/Chart.yaml
@@ -1,6 +1,6 @@
 version: 0.1.6
 apiVersion: v2
-appVersion: "5.2"
+appVersion: "5.4.4-1"
 name: thehive
 description: The official Helm chart of TheHive for Kubernetes.
 type: application
@@ -43,6 +43,6 @@ annotations:
       image: strangebee/thehive:5.2
       whitelisted: true
 
-## For reference: 
+## For reference:
 ## https://helm.sh/docs/topics/charts/#the-chartyaml-file
 ## https://artifacthub.io/docs/topics/annotations/helm/

--- a/charts/thehive/Chart.yaml
+++ b/charts/thehive/Chart.yaml
@@ -1,6 +1,6 @@
 version: 0.1.6
 apiVersion: v2
-appVersion: "5.4.4-1"
+appVersion: "5.4.5-1"
 name: thehive
 description: The official Helm chart of TheHive for Kubernetes.
 type: application

--- a/charts/thehive/templates/database/statefulset.yaml
+++ b/charts/thehive/templates/database/statefulset.yaml
@@ -31,7 +31,8 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
         - name: cassandra
-          image: "cassandra:{{ .Values.cassandra.version }}"
+          image: "{{ .Values.cassandra.image.registry }}/{{ .Values.cassandra.image.repository }}:{{ .Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
           ports:
             - containerPort: 7000
               name: intra-node

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -34,17 +34,19 @@ spec:
       # See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#init-containers-in-use
       initContainers:
         - name: init-cassandra
-          image: busybox:1.28
+          image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
+          imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
           command: ['sh', '-c', "until nslookup {{ index .Values.thehive.cql.hostnames 0 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cassandra; sleep 2; done"]
         - name: init-elastic
-          image: busybox:1.28
+          image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
+          imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
           command: ['sh', '-c', "until nslookup {{ index .Values.thehive.indexBackend.hostnames 0 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for elasticsearch; sleep 2; done"]
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "/opt/thehive/entrypoint"

--- a/charts/thehive/templates/minio/pod.yaml
+++ b/charts/thehive/templates/minio/pod.yaml
@@ -14,7 +14,8 @@ spec:
   restartPolicy: OnFailure
   containers:
     - name: minio-mc
-      image: minio/mc
+      image: "{{ .Values.minio.minioClient.image.registry }}/{{ .Values.minio.minioClient.image.repository }}:{{ .Values.minio.minioClient.image.tag }}"
+      imagePullPolicy: {{ .Values.minio.minioClient.image.pullPolicy }}
       command: ["/bin/sh", "-c",
         "until (/usr/bin/mc config host add myminio $MINIO_ENDPOINT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY) do echo '...waiting...' && sleep 1; done;
           /usr/bin/mc mb --ignore-existing myminio/state-storage;

--- a/charts/thehive/templates/minio/sts.yaml
+++ b/charts/thehive/templates/minio/sts.yaml
@@ -32,7 +32,8 @@ spec:
       containers:
         - name: thehive-minio
           # Pulls the default Minio image from Docker Hub
-          image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+          image: "{{ .Values.minio.image.registry }}/{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
           args:
             - server
             - /storage

--- a/charts/thehive/templates/tests/test-connection.yaml
+++ b/charts/thehive/templates/tests/test-connection.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
+      imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
       command: ['wget']
       args: ['{{ include "thehive.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -146,8 +146,8 @@ thehive:
     enabled: true
   # -- PodDisruptionBudget configuration
   maxUnavailable: 1
-  # -- TheHive Secret
-  secret: "SuperSecretForKubernetes"
+  # -- TheHive Secret (must be at least 32 characters long)
+  secret: "YouShouldChangeThisSecretWithOneOfAtLeast32Chars"
   # -- TheHive Nodes count
   clusterMinNodesCount: 1
   # -- Cortex configuration

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -5,10 +5,11 @@
 replicaCount: 1
 
 image:
+  registry: docker.io
   repository: strangebee/thehive
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Defaults to the chart appVersion, can be overridden here
   tag: ""
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""
@@ -17,7 +18,11 @@ fullnameOverride: ""
 cassandra:
   # -- Enable Cassandra database
   enabled: true
-  version: "4.1"
+  image:
+    registry: docker.io
+    repository: cassandra
+    tag: "4.1"
+    pullPolicy: IfNotPresent
   # -- Cassandra cluster name
   clusterName: "TheHive"
   # -- Cassandra datacenter name
@@ -103,8 +108,18 @@ minio:
   endpoint: http://thehive-minio:9000
 
   image:
+    registry: docker.io
     repository: minio/minio
     tag: RELEASE.2024-01-18T22-51-28Z
+    pullPolicy: IfNotPresent
+
+  # -- MinIO client image
+  minioClient:
+    image:
+      registry: docker.io
+      repository: minio/mc
+      tag: RELEASE.2024-11-17T19-35-25Z
+      pullPolicy: IfNotPresent
 
   # -- Minio authentification configuration
   auth:
@@ -116,6 +131,13 @@ minio:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+busybox:
+  image:
+    registry: docker.io
+    repository: busybox
+    tag: "1.28"
+    pullPolicy: IfNotPresent
 
 thehive:
   # -- Init containers will execute nslookup to resolve the hostnames of cassandra and elasticsearch

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -21,7 +21,7 @@ cassandra:
   image:
     registry: docker.io
     repository: cassandra
-    tag: "4.1"
+    tag: "4.1.7"
     pullPolicy: IfNotPresent
   # -- Cassandra cluster name
   clusterName: "TheHive"
@@ -110,7 +110,7 @@ minio:
   image:
     registry: docker.io
     repository: minio/minio
-    tag: RELEASE.2024-01-18T22-51-28Z
+    tag: RELEASE.2024-11-07T00-52-20Z
     pullPolicy: IfNotPresent
 
   # -- MinIO client image
@@ -136,7 +136,7 @@ busybox:
   image:
     registry: docker.io
     repository: busybox
-    tag: "1.28"
+    tag: "1.36-glibc"
     pullPolicy: IfNotPresent
 
 thehive:


### PR DESCRIPTION
Changes summary:
- Bump TheHive version from `5.2` to `5.4.5-1`
- Pin Cassandra version to `4.1.7`
- Pin MinIO version to `RELEASE.2024-11-07T00-52-20Z`
- Pin MinIO Client version to `RELEASE.2024-11-17T19-35-25Z`
- Pin BusyBox version to `1.36-glibc`
- Update TheHive default HTTP secret to comply with the 32+ characters requirement