### PR TITLE
Replace ElasticSearch unmaintained Helm Chart

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- Replace ElasticSearch unmaintained Helm Chart [#19](https://github.com/StrangeBeeCorp/helm-charts/pull/19)
 
 
 ## 0.1.7

--- a/charts/thehive/Chart.yaml
+++ b/charts/thehive/Chart.yaml
@@ -23,8 +23,8 @@ sources:
 
 dependencies:
   - name: elasticsearch
-    version: 7.17.3
-    repository: https://helm.elastic.co
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 21.3.26
     condition: elasticsearch.enabled
 
 annotations:

--- a/charts/thehive/README.md
+++ b/charts/thehive/README.md
@@ -34,7 +34,7 @@ helm install [RELEASE_NAME] strangebee/thehive
 ## Dependencies
 
 This Chart relies on the following Helm Charts by default:
-- [deprecated] [elastic/elasticsearch](https://github.com/elastic/helm-charts/tree/main/elasticsearch) - used as index
+- [bitnami/charts elasticsearch](https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch) - used as index
 
 In addition, this Chart deploys additional services for TheHive to work out of the box:
 - [cassandra](https://hub.docker.com/_/cassandra) - used as database
@@ -78,7 +78,7 @@ To configure StorageClasses according to your needs, you should check out releva
 
 ### ElasticSearch
 
-By default, this Chart will deploy an ElasticSearch cluster made of 2 nodes (with one master node).
+By default, this Chart will deploy an ElasticSearch cluster made of 2 nodes (both master-eligible and general purposed).
 
 You can check out [the related Helm Chart](./README.md#dependencies) to see configuration options.
 

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: init-elastic
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
-          command: ['sh', '-c', "until nslookup {{ index .Values.thehive.indexBackend.hostnames 0 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for elasticsearch; sleep 2; done"]
+          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.thehive.indexBackend.hostnames 0 }}{{ if .Values.elasticsearch.enabled }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local{{ end }}:{{ .Values.thehive.indexBackend.port }}/_cluster/health ; do echo waiting for elasticsearch; sleep 2; done"]
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -75,11 +75,11 @@ elasticsearch:
     # Defined in https://github.com/bitnami/charts/blob/elasticsearch/21.3.26/bitnami/common/templates/_resources.tpl
     resourcesPreset: "small"
     # Master nodes heap size
-    heapSize: 128m
+    heapSize: 96m
     # Configure JVM options as env variable
     extraEnvVars:
       - name: JVM_OPTS
-        value: "-Xms128m -Xmx128m -Xmn128m"
+        value: "-Xms96m -Xmx96m -Xmn96m"
     # WARNING - should be set to "hard" or configured manually with "elasticsearch.master.affinity" in production
     podAffinityPreset: "soft"
 

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -160,7 +160,7 @@ thehive:
   cql:
     # -- Cassandra hostnames
     hostnames:
-      - "thehive-elasticsearch"
+      - "thehive-cassandra"
     # -- Wait for Cassandra
     wait: true
   # -- Index Backend configuration
@@ -169,7 +169,7 @@ thehive:
     type: elasticsearch
     # -- Elasticsearch hostnames
     hostnames:
-      - "elasticsearch-master"
+      - "thehive-elasticsearch"
   # -- Object Storage configuration
   # @default -- {}
   s3:

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -56,50 +56,49 @@ cassandra:
     # -- Cassandra volume mode (Filesystem or Block)
     volumeMode: Filesystem
 
-# -- For more information: https://github.com/elastic/helm-charts/tree/main/elasticsearch
-# @default -- {}
+
+# https://github.com/bitnami/charts/blob/elasticsearch/21.3.26/bitnami/elasticsearch/values.yaml
 elasticsearch:
-  # -- Enable Elasticsearch
+  # Use ElasticSearch dependency Helm Chart
   enabled: true
-  # -- Replicas count
-  replicas: 2
-  # -- Master nodes
-  minimumMasterNodes: 1
-  # -- Set to true in production
-  createCert: false
-  # -- Set to true in production
-  secret:
-    enabled: false # WARNING: In production you should enable this
-  # -- Disable xpack security
-  # @default -- {esConfig: {}}
-  esConfig:
-    elasticsearch.yml: |
-      xpack.security.enabled: false
-      xpack.security.transport.ssl.enabled: false
-      xpack.security.http.ssl.enabled: false
-  # -- Permit co-located instances for solitary minikube virtual machines.
-  antiAffinity: "soft"
 
-  # -- Shrink default JVM heap.
-  esJavaOpts: "-Xmx128m -Xms128m"
+  image:
+    registry: docker.io
+    repository: bitnami/elasticsearch
+    tag: "7.17.25-debian-12-r3"
 
-  # -- Allocate smaller chunks of memory per pod.
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "512Mi"
-    limits:
-      cpu: "1000m"
-      memory: "512Mi"
+  master:
+    # Use master nodes as multipurpose nodes (master, data, coordinating and ingest) to simplify the deployment
+    masterOnly: false
+    # Number of master-elegible replicas to deploy
+    replicaCount: 2
+    # Defined in https://github.com/bitnami/charts/blob/elasticsearch/21.3.26/bitnami/common/templates/_resources.tpl
+    resourcesPreset: "small"
+    # Master nodes heap size
+    heapSize: 128m
+    # Configure JVM options as env variable
+    extraEnvVars:
+      - name: JVM_OPTS
+        value: "-Xms128m -Xmx128m -Xmn128m"
+    # WARNING - should be set to "hard" or configured manually with "elasticsearch.master.affinity" in production
+    podAffinityPreset: "soft"
 
-  # -- Request smaller persistent volumes.
-  # @default -- {}
-  volumeClaimTemplate:
-    accessModes: ["ReadWriteOnce"]
-    storageClassName: "standard"
-    resources:
-      requests:
-        storage: "500Mi"
+  data:
+    # Disable data-dedicated nodes
+    replicaCount: 0
+
+  coordinating:
+    # Disable coordination-dedicated nodes
+    replicaCount: 0
+
+  ingest:
+    # Disable ingestion-dedicated nodes
+    replicaCount: 0
+
+  security:
+    # WARNING - security options should be enabled in production
+    enabled: false
+
 
 minio:
   # -- Enable Minio
@@ -161,7 +160,7 @@ thehive:
   cql:
     # -- Cassandra hostnames
     hostnames:
-      - "thehive-cassandra"
+      - "thehive-elasticsearch"
     # -- Wait for Cassandra
     wait: true
   # -- Index Backend configuration

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -65,7 +65,7 @@ elasticsearch:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch
-    tag: "7.17.25-debian-12-r3"
+    tag: "8.16.1-debian-12-r1"
 
   master:
     # Use master nodes as multipurpose nodes (master, data, coordinating and ingest) to simplify the deployment

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -163,13 +163,14 @@ thehive:
       - "thehive-cassandra"
     # -- Wait for Cassandra
     wait: true
-  # -- Index Backend configuration
+  # Index backend configuration
   indexBackend:
-    # -- Elasticsearch is the only supported backend for now
     type: elasticsearch
-    # -- Elasticsearch hostnames
+    # ElasticSearch cluster hostnames
     hostnames:
       - "thehive-elasticsearch"
+    # ElasticSearch API port
+    port: "9200"
   # -- Object Storage configuration
   # @default -- {}
   s3:


### PR DESCRIPTION
Changes summary:
- Replace unmaintained [elastic/helm-charts](https://github.com/elastic/helm-charts/tree/main/elasticsearch) with [bitnami/charts](https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch) as Helm Chart dependency to create an ElasticSearch cluster
- Update the default `values.yaml` to match parameters expected by the new Helm Chart dependency
- Update ElasticSearch image version from `elasticsearch:7.17.3` to `bitnami/elasticsearch:8.16.1-debian-12-r1`
- Improve the test made by `init-elastic` initContainer to check that the ElasticSearch cluster is reachable
    * It now waits for a response from ElasticSearch `/_cluster/health` API route
- Update ElasticSearch JVM parameters to fit within the new resources limits