### PR TITLE
Rework GitHub workflow

### DIFF
--- a/.github/workflows/release-thehive.yml
+++ b/.github/workflows/release-thehive.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-thehive.yml
+++ b/.github/workflows/release-thehive.yml
@@ -31,7 +31,13 @@ jobs:
         run: |
           helm repo add minio https://charts.min.io/
 
+      # At the time of writing, the "helm/chart-releaser-action" does not support multiple Helm Charts
+      # https://github.com/helm/chart-releaser-action/issues/198
+      #
+      # For now we only have TheHive Helm Chart defined, but adding other Charts will create issues
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-thehive.yml
+++ b/.github/workflows/release-thehive.yml
@@ -1,3 +1,4 @@
+# Based on https://github.com/helm/chart-releaser-action
 name: Release TheHive Helm Chart
 
 on:
@@ -21,9 +22,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Add Helm repos
+      - name: Add Helm Repositories related to the Helm Charts specified as dependencies
         run: |
-          helm repo add elastic https://helm.elastic.co
+          helm repo add minio https://charts.min.io/
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/.github/workflows/release-thehive.yml
+++ b/.github/workflows/release-thehive.yml
@@ -1,11 +1,9 @@
-name: Release Charts
+name: Release TheHive Helm Chart
 
 on:
   push:
-    # branches:
-    #   - main
     tags:
-      - '*'
+      - thehive-*
 
 jobs:
   release:

--- a/.github/workflows/release-thehive.yml
+++ b/.github/workflows/release-thehive.yml
@@ -22,6 +22,11 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Add Helm Repositories related to the Helm Charts specified as dependencies
         run: |
           helm repo add minio https://charts.min.io/

--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Replace ElasticSearch unmaintained Helm Chart [#19](https://github.com/StrangeBeeCorp/helm-charts/pull/19)
 - Use Bitnami Cassandra Helm Chart [#20](https://github.com/StrangeBeeCorp/helm-charts/pull/20)
 - Use MinIO (community) Helm Chart [#21](https://github.com/StrangeBeeCorp/helm-charts/pull/21)
+- Rework GitHub workflow [#22](https://github.com/StrangeBeeCorp/helm-charts/pull/22)
 
 
 ## 0.1.7


### PR DESCRIPTION
Changes summary:
- Only create a new TheHive Helm Chart release when the tag is like `thehive-*`
- Remove Elastic Helm Repository and add MinIO one to match current Helm Chart dependencies
- Add step to install Helm
- Update `actions/checkout` step from v3 to v4 (to fix warning in GitHub Actions tab)
- Add information on `helm/chart-releaser-action` step which only supports one Helm Chart for now