### PR TITLE
Improve default values for production use

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update READMEs and ArtifactHub information [#24](https://github.com/StrangeBeeCorp/helm-charts/pull/24)
 - Add Secret and improve ConfigMaps usage [#25](https://github.com/StrangeBeeCorp/helm-charts/pull/25)
 - Tweak subcharts configurations [#26](https://github.com/StrangeBeeCorp/helm-charts/pull/26)
+- Improve default values for production use [#27](https://github.com/StrangeBeeCorp/helm-charts/pull/27)
 
 
 ## 0.1.7

--- a/charts/thehive/templates/_helpers.tpl
+++ b/charts/thehive/templates/_helpers.tpl
@@ -49,9 +49,5 @@ app.kubernetes.io/component: "frontend"
 
 {{/* TheHive service account name */}}
 {{- define "thehive.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-  {{- default (include "thehive.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-  {{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{- default (include "thehive.fullname" .) .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -50,13 +50,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "/opt/thehive/entrypoint"
-            {{ if not .Values.database.wait -}}- "--no-cql-wait"{{- end }}
-            {{ if not .Values.cortex.enabled -}}- "--no-config-cortex"{{- end }}
             - "--kubernetes"
             - "--kubernetes-pod-label-selector"
             - "app.kubernetes.io/name={{ include "thehive.name" . }}"
+            {{ if not .Values.cortex.enabled -}}- "--no-config-cortex"{{- end }}
+            {{ if not .Values.database.wait -}}- "--no-cql-wait"{{- end }}
             - "--index-backend"
             - "elasticsearch"
+            {{ if .Values.storage.usePathAccessStyle -}}- "--s3-use-path-access-style"{{- end }}
             - "--cluster-min-nodes-count"
             - "{{ .Values.clusterMinNodesCount }}"
           {{- with .Values.extraCommand }}

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -66,6 +66,8 @@ spec:
             {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
+            - name: JVM_OPTS
+              value: {{ .Values.jvmOpts | quote }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/thehive/templates/serviceaccount.yaml
+++ b/charts/thehive/templates/serviceaccount.yaml
@@ -10,9 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
-{{ end -}}
 
-{{- if .Values.serviceAccount.podReader.attach -}}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,7 +19,7 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 rules:
-  - apiGroups: [""] # "" indicates the core API group
+  - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "watch", "list"]
 
@@ -29,7 +27,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "thehive.serviceAccountName" . }}-read-pods
+  name: {{ include "thehive.serviceAccountName" . }}-pod-reader-binding
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 subjects:
@@ -37,10 +35,6 @@ subjects:
     name: {{ include "thehive.serviceAccountName" . }}
 roleRef:
   kind: Role
-  {{- if .Values.serviceAccount.podReader.serviceAccountName }}
-  name: {{ .Values.serviceAccount.podReader.serviceAccountName }}
-  {{- else}}
   name: {{ include "thehive.serviceAccountName" . }}-pod-reader
-  {{- end }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -15,7 +15,7 @@ image:
 
 imagePullSecrets: []
 
-replicaCount: 1
+replicaCount: 2
 
 # TheHive nodes count
 clusterMinNodesCount: 1
@@ -25,18 +25,22 @@ maxUnavailable: 1
 
 autoscaling:
   enabled: false
-  minReplicas: 1
-  maxReplicas: 5
+  minReplicas: 2
+  maxReplicas: 4
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 95
 
-resources: {}
-  #requests:
-  #  cpu: 100m
-  #  memory: 128Mi
-  #limits:
-  #  cpu: 100m
-  #  memory: 128Mi
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2048Mi"
+    ephemeral-storage: "4Gi"
+  limits:
+    cpu: "3000m"
+    memory: "3584Mi"
+    ephemeral-storage: "4Gi"
+
+jvmOpts: "-Xms2g -Xmx2g -Xmn300m"
 
 # TheHive Cassandra configuration
 database:

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -391,11 +391,11 @@ minio:
     requests:
       cpu: "500m"
       memory: "2Gi"
-      ephemeral-storage: "2Gi"
+      ephemeral-storage: "4Gi"
     limits:
       cpu: "1000m"
       memory: "2Gi"
-      ephemeral-storage: "2Gi"
+      ephemeral-storage: "4Gi"
 
   persistence:
     enabled: true

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -113,13 +113,23 @@ extraConfig: ""
 #extraConfig: |-
 #  # TheHive configuration file
 
-# Extra entrypoint arguments. See: https://docs.strangebee.com/thehive/setup/installation/docker/#all-options
+# Extra entrypoint arguments
 extraCommand: []
 
 # Extra environment variables
 extraEnv: []
 #  - name: "EXAMPLE"
 #    value: "example"
+#  - name: "FROM_CM"
+#    valueFrom:
+#      configMapKeyRef:
+#        name: "cm-name"
+#        key: "key-name"
+#  - name: "FROM_SECRET"
+#    valueFrom:
+#      secretKeyRef:
+#        name: "cm-name"
+#        key: "key-name"
 
 # Liveness probes
 livenessProbe:
@@ -130,21 +140,14 @@ readinessProbe:
   enabled: true
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # Create a ServiceAccount for TheHive
   create: true
+  # The name of the service account to use (generated automatically if empty)
+  name: ""
   # Whether to automatically mount the Service Account's token in pod
   automount: true
   # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
-  # Attach pod reader role to service account
-  podReader:
-    # Specifies whether a pod reader role should be attached. Required to running thehive in cluster mode
-    attach: true
-    # The name of the service account to map pod reader role.
-    serviceAccountName: ""
 
 podAnnotations: {}
 podLabels: {}

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -104,12 +104,9 @@ httpSecret: ""
 k8sSecretName: ""
 k8sSecretKey: "http-secret"
 
-# Cortex configuration
+# Cortex configuration (not implemented yet)
 cortex:
   enabled: false
-  hostnames:
-    - "thehive-cortex"
-  keys: ""
 
 # Custom application.conf file for TheHive (included on startup)
 extraConfig: ""

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -228,7 +228,7 @@ cassandra:
     datacenter: "DC1-TheHive"
     rack: "Rack1-TheHive"
 
-  replicaCount: 1
+  replicaCount: 2
 
   pdb:
     create: true
@@ -239,18 +239,18 @@ cassandra:
   resources:
     requests:
       cpu: "1000m"
-      memory: "2Gi"
-      ephemeral-storage: "2Gi"
+      memory: "2048Mi"
+      ephemeral-storage: "4Gi"
     limits:
-      cpu: "1000m"
-      memory: "2Gi"
-      ephemeral-storage: "2Gi"
+      cpu: "2000m"
+      memory: "3584Mi"
+      ephemeral-storage: "4Gi"
 
   # https://docs.datastax.com/en/archived/cassandra/2.0/cassandra/operations/ops_tune_jvm_c.html
   jvm:
-    extraOpts: "-Xms128m -Xmx512m -Xmn128m"
-    maxHeapSize: "512m"
-    newHeapSize: "128m"
+    extraOpts: "-Xms2g -Xmx2g -Xmn200m"
+    maxHeapSize: "2g"
+    newHeapSize: "200m"
 
   persistence:
     enabled: true

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -305,19 +305,19 @@ elasticsearch:
     resources:
       requests:
         cpu: "1000m"
-        memory: "2Gi"
-        ephemeral-storage: "2Gi"
+        memory: "2048Mi"
+        ephemeral-storage: "4Gi"
       limits:
-        cpu: "1000m"
-        memory: "2Gi"
-        ephemeral-storage: "2Gi"
+        cpu: "2000m"
+        memory: "3584Mi"
+        ephemeral-storage: "4Gi"
 
     # Master nodes heap size
-    heapSize: 512m
+    heapSize: "2g"
     # Configure JVM options as env variable
     extraEnvVars:
       - name: JVM_OPTS
-        value: "-Xms128m -Xmx512m -Xmn128m"
+        value: "-Xms2g -Xmx2g -Xmn200m"
 
     persistence:
       enabled: true

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -112,24 +112,25 @@ cortex:
 extraConfig: ""
 #extraConfig: |-
 #  # TheHive configuration file
+#  # See https://docs.strangebee.com/thehive/overview/ under the "Configuration" section
 
 # Extra entrypoint arguments
 extraCommand: []
 
 # Extra environment variables
 extraEnv: []
-#  - name: "EXAMPLE"
-#    value: "example"
-#  - name: "FROM_CM"
-#    valueFrom:
-#      configMapKeyRef:
-#        name: "cm-name"
-#        key: "key-name"
-#  - name: "FROM_SECRET"
-#    valueFrom:
-#      secretKeyRef:
-#        name: "cm-name"
-#        key: "key-name"
+  #- name: "EXAMPLE"
+  #  value: "example"
+  #- name: "FROM_CM"
+  #  valueFrom:
+  #    configMapKeyRef:
+  #      name: "cm-name"
+  #      key: "key-name"
+  #- name: "FROM_SECRET"
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: "cm-name"
+  #      key: "key-name"
 
 # Liveness probes
 livenessProbe:
@@ -152,16 +153,14 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+# https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# Pod wide security context
 podSecurityContext: {}
-  # fsGroup: 2000
+  #fsGroup: 2000
 
+# Container wide security context
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  #allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP
@@ -171,30 +170,30 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+    #kubernetes.io/ingress.class: nginx
+    #kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    #- secretName: chart-example-tls
+    #  hosts:
+    #    - chart-example.local
 
-# Additional volumes on the output Deployment definition.
+# Additional volumes for TheHive Deployment
 volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
+  #- name: foo
+  #  secret:
+  #    secretName: mysecret
+  #    optional: false
 
-# Additional volumeMounts on the output Deployment definition.
+# Additional volumeMounts for TheHive Deployment
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
+  #- name: foo
+  #  mountPath: "/etc/foo"
+  #  readOnly: true
 
 nodeSelector: {}
 


### PR DESCRIPTION
Changes summary:
- Raise TheHive and Cassandra to 2 replicas
- Tweak resources requests and limits for TheHive, Cassandra, ElasticSearch and MinIO
- Add and configure `JVM_OPTS` in TheHive Deployment
- Update `JVM_OPTS` for Cassandra and ElasticSearch
- Simplify ServiceAccount Helm template
- Add missing s3 flag for TheHive
- Update comments in `values.yaml`