### PR TITLE
Fix MinIO bucket configuration

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add Secret and improve ConfigMaps usage [#25](https://github.com/StrangeBeeCorp/helm-charts/pull/25)
 - Tweak subcharts configurations [#26](https://github.com/StrangeBeeCorp/helm-charts/pull/26)
 - Improve default values for production use [#27](https://github.com/StrangeBeeCorp/helm-charts/pull/27)
+- Fix MinIO bucket configuration [#28](https://github.com/StrangeBeeCorp/helm-charts/pull/28)
 
 
 ## 0.1.7

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -380,16 +380,6 @@ minio:
       purge: false
       versioning: false
       objectlocking: false
-    - name: state-storage
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
-    - name: thehive-dev-logs
-      policy: none
-      purge: false
-      versioning: false
-      objectlocking: false
 
   resources:
     requests:

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -375,6 +375,11 @@ minio:
     maxUnavailable: 1
 
   buckets:
+    - name: thehive
+      policy: none
+      purge: false
+      versioning: false
+      objectlocking: false
     - name: state-storage
       policy: none
       purge: false


### PR DESCRIPTION
Changes summary:
- Add MinIO config to create a bucket named `thehive` (as expected by TheHive config)
- Remove unneeded buckets