### PR TITLE
Fix ConfigMap mount to prevent overwriting files in "/etc/thehive" folder

### DIFF
--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -130,8 +130,8 @@ spec:
           volumeMounts:
           {{- if .Values.extraConfig }}
             - name: config
-              mountPath: /etc/thehive
-              readOnly: true
+              mountPath: /etc/thehive/application.conf
+              subPath: application.conf
           {{- end -}}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -132,6 +132,7 @@ spec:
             - name: config
               mountPath: /etc/thehive/application.conf
               subPath: application.conf
+              readOnly: true
           {{- end -}}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Changes summary:
- Add file specific `mountPath` and `subPath` to prevent overwriting files from `/etc/thehive` folder