### PR TITLE
Fix TheHive crashLoop on first start using a startupProbe

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- Fix TheHive crashLoop on first start using a startupProbe [#31](https://github.com/StrangeBeeCorp/helm-charts/pull/31)
 
 
 ## 0.2.0

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -112,6 +112,13 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 36
+            periodSeconds: 5
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -132,11 +132,15 @@ extraEnv: []
   #      name: "cm-name"
   #      key: "key-name"
 
-# Liveness probes
+# Startup probe
+startupProbe:
+  enabled: true
+
+# Liveness probe
 livenessProbe:
   enabled: true
 
-# Readiness probes
+# Readiness probe
 readinessProbe:
   enabled: true
 


### PR DESCRIPTION
Changes summary:
- Add a `startupProbe` to prevent the `livenessProbe` from killing TheHive pods on first start (when TheHive is initializing the database and index)
- Add a parameter in `values.yaml` to disable the `startupProbe` if needed