### PR TITLE
Fix the CM template used to create a custom "application.conf" file

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - Fix TheHive crashLoop on first start using a startupProbe [#31](https://github.com/StrangeBeeCorp/helm-charts/pull/31)
+- Fix the CM template used to create a custom "application.conf" file [#32](https://github.com/StrangeBeeCorp/helm-charts/pull/32)
 
 
 ## 0.2.0

--- a/charts/thehive/templates/configmap-file.yaml
+++ b/charts/thehive/templates/configmap-file.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "thehive.fullname" . }}-config
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
-data: |
-  {{- toYaml .Values.extraConfig | nindent 2 }}
+data:
+  application.conf: |
+    {{- toYaml .Values.extraConfig | nindent 4 }}
 {{- end -}}

--- a/charts/thehive/templates/configmap-file.yaml
+++ b/charts/thehive/templates/configmap-file.yaml
@@ -6,6 +6,5 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:
-  application.conf: |
-    {{- toYaml .Values.extraConfig | nindent 4 }}
+  application.conf: {{- .Values.extraConfig | toYaml | indent 1 }}
 {{- end -}}

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -110,7 +110,7 @@ cortex:
 
 # Custom application.conf file for TheHive (included on startup)
 extraConfig: ""
-#extraConfig: |-
+#extraConfig: |
 #  # TheHive configuration file
 #  # See https://docs.strangebee.com/thehive/overview/ under the "Configuration" section
 


### PR DESCRIPTION
Changes summary:
- Fix missing level in the ConfigMap template used to create a custom `application.conf` file
- Update the comment containing a sample `extraConfig` multiline value in `values.yaml` file