### PR TITLE
Update TheHive Helm Chart README

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix TheHive crashLoop on first start using a startupProbe [#31](https://github.com/StrangeBeeCorp/helm-charts/pull/31)
 - Fix the CM template used to create a custom "application.conf" file [#32](https://github.com/StrangeBeeCorp/helm-charts/pull/32)
+- Update TheHive Helm Chart README [#33](https://github.com/StrangeBeeCorp/helm-charts/pull/33)
 
 
 ## 0.2.0

--- a/charts/thehive/README.md
+++ b/charts/thehive/README.md
@@ -47,7 +47,7 @@ helm upgrade [RELEASE_NAME] strangebee/thehive
 ```
 
 
-## Configuration
+## Customizing this Chart
 
 > [!TIP]
 > See [Helm documentation on how to customize a Chart before installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)
@@ -59,12 +59,22 @@ helm show values strangebee/thehive
 
 You should also check available options [from this Chart's dependencies](./README.md#dependencies) to customize other services.
 
+
+## Default configuration and best practices
+
+For convenience, this Helm Chart is provided with all required components out of the box.
+While this can be a good fit for a dev environment, it is **highly recommended** to review all dependencies before moving to production.
+
+
 ### Storage considerations
+
+> [!IMPORTANT]
+> Regular backups of your PVs are **paramount** to prevent data loss
 
 If not changed, this Chart uses **your default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/)** to create persistent volumes.
 
 You should make sure that the StorageClass you use:
-- Is backed up regularly
+- Is backed up regularly (some tools like [Velero](https://velero.io/) can help automate backups)
 - Has a fitting `reclaimPolicy` to reduce the risk of data loss
 
 To configure StorageClasses according to your needs, you should check out relevant CSI drivers for your infrastructure
@@ -80,7 +90,7 @@ You can check out [the related Helm Chart](./README.md#dependencies) to see conf
 
 ### Cassandra
 
-A single Cassandra pod is started by this Chart to store TheHive's data.
+Two Cassandra pods are started by this Chart to store TheHive's data.
 
 You can check out [the related Helm Chart](./README.md#dependencies) to see configuration options.
 
@@ -92,3 +102,5 @@ To support multiple replicas of TheHive, we define an object storage in the conf
 However, we recommend that you use a managed object storage service to guarantee the best performance and resilience of your deployment, such as:
 - [AWS s3](https://aws.amazon.com/s3/)
 - [GCP Cloud Storage](https://cloud.google.com/storage)
+
+Do note that [network shared filesystem (e.g. NFS)](https://docs.strangebee.com/thehive/installation/deploying-a-cluster/#file-storage) is supported too, but it can be trickier to implement and slower.

--- a/charts/thehive/README.md
+++ b/charts/thehive/README.md
@@ -14,7 +14,7 @@ The [official Helm Chart](https://github.com/StrangeBeeCorp/helm-charts) of [The
 ## Using the Chart
 
 > [!TIP]
-> For more options, check out [helm install](https://helm.sh/docs/helm/helm_install/) documentation and [the configuration section](./README.md#configuration) of this page
+> For more options, check out [helm install](https://helm.sh/docs/helm/helm_install/) documentation and [the customization section](./README.md#customizing-this-chart) of this page
 
 ```bash
 # Add StrangeBee Helm Repository


### PR DESCRIPTION
Changes summary:
- Fix typo on the number of Cassandra replicas deployed by default
- Add details on the default configuration and best practices