### PR TITLE
Update TheHive softwares versions

### DIFF
--- a/charts/thehive/Chart.yaml
+++ b/charts/thehive/Chart.yaml
@@ -9,7 +9,7 @@ kubeVersion: ">= 1.23.0"
 dependencies:
   - name: cassandra
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 12.0.4
+    version: 12.0.5
     condition: cassandra.enabled
   - name: elasticsearch
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/thehive/Chart.yaml
+++ b/charts/thehive/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 
 name: thehive
 version: 0.2.0
-appVersion: "5.4.5-1"
+appVersion: "5.4.7-1"
 kubeVersion: ">= 1.23.0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.4.5-1
+      image: strangebee/thehive:5.4.7-1
       whitelisted: true
     - name: busybox
       image: busybox:1.36-glibc

--- a/charts/thehive/README.md
+++ b/charts/thehive/README.md
@@ -1,6 +1,6 @@
 # TheHive Helm Chart
 
-[![Chart version 0.2.0](https://img.shields.io/badge/Chart_version-0.2.0-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.2.0) [![App version 5.4.5-1](https://img.shields.io/badge/App_version-5.4.5--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/)
+[![Chart version 0.2.0](https://img.shields.io/badge/Chart_version-0.2.0-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.2.0) [![App version 5.4.7-1](https://img.shields.io/badge/App_version-5.4.7--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/)
 
 The [official Helm Chart](https://github.com/StrangeBeeCorp/helm-charts) of [TheHive](https://strangebee.com/thehive/) for Kubernetes.
 

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -209,7 +209,7 @@ affinity: {}
 # Cassandra subchart variables #
 ################################
 
-# https://github.com/bitnami/charts/blob/cassandra/12.0.4/bitnami/cassandra/values.yaml
+# https://github.com/bitnami/charts/blob/cassandra/12.0.5/bitnami/cassandra/values.yaml
 cassandra:
   # Use Cassandra dependency Helm Chart
   enabled: true
@@ -217,7 +217,7 @@ cassandra:
   image:
     registry: docker.io
     repository: bitnami/cassandra
-    tag: "4.1.7-debian-12-r2"
+    tag: "4.1.7-debian-12-r3"
 
   dbUser:
     user: "cassandra"


### PR DESCRIPTION
Changes summary:
- Bump TheHive version [from `5.4.5-1` to `5.4.7-1`](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/#547-16th-of-january-2025)
- Bump Cassandra dependency Chart version [from `12.0.4` to `12.0.5`](https://github.com/bitnami/charts/blob/main/bitnami/cassandra/CHANGELOG.md#1205-2024-11-28)