### PR TITLE
Update TheHive version from 5.4.7-1 to 5.4.8-1

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- Update TheHive version from 5.4.7-1 to 5.4.8-1 [#37](https://github.com/StrangeBeeCorp/helm-charts/pull/37)
 
 
 ## 0.2.1

--- a/charts/thehive/Chart.yaml
+++ b/charts/thehive/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 
 name: thehive
 version: 0.2.1
-appVersion: "5.4.7-1"
+appVersion: "5.4.8-1"
 kubeVersion: ">= 1.23.0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.4.7-1
+      image: strangebee/thehive:5.4.8-1
       whitelisted: true
     - name: busybox
       image: busybox:1.36.1-glibc

--- a/charts/thehive/README.md
+++ b/charts/thehive/README.md
@@ -1,6 +1,6 @@
 # TheHive Helm Chart
 
-[![Chart version 0.2.1](https://img.shields.io/badge/Chart_version-0.2.1-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.2.1) [![App version 5.4.7-1](https://img.shields.io/badge/App_version-5.4.7--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/)
+[![Chart version 0.2.1](https://img.shields.io/badge/Chart_version-0.2.1-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.2.1) [![App version 5.4.8-1](https://img.shields.io/badge/App_version-5.4.8--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/)
 
 The [official Helm Chart](https://github.com/StrangeBeeCorp/helm-charts) of [TheHive](https://strangebee.com/thehive/) for Kubernetes.
 


### PR DESCRIPTION
> [!NOTE]
> To guarantee backward compatibility, only patch updates were applied in this PR. An update to the latest version of each dependency should follow in the coming weeks.

Changes summary:
- Bump TheHive version [from `5.4.7-1` to `5.4.8-1`](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/#548-february-24-2025)