### PR TITLE
Add cluster domain configuration

### DIFF
--- a/charts/thehive/CHANGELOG.md
+++ b/charts/thehive/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - Update TheHive version from 5.4.7-1 to 5.4.8-1 [#37](https://github.com/StrangeBeeCorp/helm-charts/pull/37)
+- Add cluster domain configuration [#38](https://github.com/StrangeBeeCorp/helm-charts/pull/38)
 
 
 ## 0.2.1

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: init-cassandra
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
-          command: ['sh', '-c', "until nslookup {{ index .Values.database.hostnames 0 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc{{ if .Values.clusterDomain }}.{{ .Values.clusterDomain }}{{ end }}; do echo waiting for cassandra; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup {{ index .Values.database.hostnames 0 }}{{ if .Values.cassandra.enabled }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc{{ if .Values.clusterDomain }}.{{ .Values.clusterDomain }}{{ end }}{{ end }}; do echo waiting for cassandra; sleep 2; done"]
         - name: init-elastic
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}

--- a/charts/thehive/templates/deployment.yaml
+++ b/charts/thehive/templates/deployment.yaml
@@ -36,11 +36,11 @@ spec:
         - name: init-cassandra
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
-          command: ['sh', '-c', "until nslookup {{ index .Values.database.hostnames 0 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cassandra; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup {{ index .Values.database.hostnames 0 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc{{ if .Values.clusterDomain }}.{{ .Values.clusterDomain }}{{ end }}; do echo waiting for cassandra; sleep 2; done"]
         - name: init-elastic
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
-          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.index.hostnames 0 }}{{ if .Values.elasticsearch.enabled }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local{{ end }}:{{ .Values.index.port }}/_cluster/health ; do echo waiting for elasticsearch; sleep 2; done"]
+          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.index.hostnames 0 }}{{ if .Values.elasticsearch.enabled }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc{{ if .Values.clusterDomain }}.{{ .Values.clusterDomain }}{{ end }}{{ end }}:{{ .Values.index.port }}/_cluster/health ; do echo waiting for elasticsearch; sleep 2; done"]
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -5,8 +5,8 @@
 nameOverride: ""
 fullnameOverride: ""
 
-# The k8s cluster's domain (often set to "cluster.local")
-clusterDomain: ""
+# The k8s cluster's domain
+clusterDomain: "cluster.local"
 
 # TheHive image
 image:

--- a/charts/thehive/values.yaml
+++ b/charts/thehive/values.yaml
@@ -5,6 +5,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# The k8s cluster's domain (often set to "cluster.local")
+clusterDomain: ""
+
 # TheHive image
 image:
   registry: docker.io


### PR DESCRIPTION
Changes summary:
- [Fixes #36] Add `clusterDomain` configuration for `initContainers` in TheHive Deployment
- Remove `.<ns>.svc` from Cassandra hostname check in `initContainers` when Cassandra dependency chart is disabled