### PR TITLE
Improve subchart services hostnames handling

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- Improve subchart services hostnames handling [#43](https://github.com/StrangeBeeCorp/helm-charts/pull/43)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/templates/configmap-env.yaml
+++ b/thehive-charts/thehive/templates/configmap-env.yaml
@@ -7,17 +7,21 @@ metadata:
 data:
   TH_CQL_USERNAME: {{ .Values.database.username | quote }}
   {{- if and (.Values.cassandra.enabled) (eq (len .Values.database.hostnames) 0) }}
-  TH_CQL_HOSTNAMES: {{ printf "%s-cassandra" .Release.Name | trunc 63 }}
+  TH_CQL_HOSTNAMES: {{ printf "%s-cassandra" .Release.Name | trunc 63 | quote }}
   {{- else }}
   TH_CQL_HOSTNAMES: {{ join "," .Values.database.hostnames | quote }}
   {{- end }}
   TH_ELASTICSEARCH_USERNAME: {{ .Values.index.username | quote }}
   {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.index.hostnames) 0) }}
-  TH_ELASTICSEARCH_HOSTNAMES: {{ printf "%s-elasticsearch" .Release.Name | trunc 63 }}
+  TH_ELASTICSEARCH_HOSTNAMES: {{ printf "%s-elasticsearch" .Release.Name | trunc 63 | quote }}
   {{- else }}
   TH_ELASTICSEARCH_HOSTNAMES: {{ join "," .Values.index.hostnames | quote }}
   {{- end }}
   TH_S3_ACCESS_KEY: {{ .Values.storage.accessKey | quote }}
+  {{- if and (.Values.minio.enabled) (empty .Values.storage.endpoint) }}
+  TH_S3_ENDPOINT: {{ printf "http://%s-minio:9000" .Release.Name | quote }}
+  {{- else }}
   TH_S3_ENDPOINT: {{ .Values.storage.endpoint | quote }}
+  {{- end }}
   TH_S3_BUCKET: {{ .Values.storage.bucket | quote }}
   TH_S3_REGION: {{ .Values.storage.region | quote }}

--- a/thehive-charts/thehive/templates/configmap-env.yaml
+++ b/thehive-charts/thehive/templates/configmap-env.yaml
@@ -6,9 +6,17 @@ metadata:
     {{- include "thehive.labels" . | nindent 4 }}
 data:
   TH_CQL_USERNAME: {{ .Values.database.username | quote }}
+  {{- if and (.Values.cassandra.enabled) (eq (len .Values.database.hostnames) 0) }}
+  TH_CQL_HOSTNAMES: {{ printf "%s-cassandra" .Release.Name | trunc 63 }}
+  {{- else }}
   TH_CQL_HOSTNAMES: {{ join "," .Values.database.hostnames | quote }}
+  {{- end }}
   TH_ELASTICSEARCH_USERNAME: {{ .Values.index.username | quote }}
+  {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.index.hostnames) 0) }}
+  TH_ELASTICSEARCH_HOSTNAMES: {{ printf "%s-elasticsearch" .Release.Name | trunc 63 }}
+  {{- else }}
   TH_ELASTICSEARCH_HOSTNAMES: {{ join "," .Values.index.hostnames | quote }}
+  {{- end }}
   TH_S3_ACCESS_KEY: {{ .Values.storage.accessKey | quote }}
   TH_S3_ENDPOINT: {{ .Values.storage.endpoint | quote }}
   TH_S3_BUCKET: {{ .Values.storage.bucket | quote }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
           {{- if and (.Values.cassandra.enabled) (eq (len .Values.database.hostnames) 0) }}
-          command: ['sh', '-c', "until nc -v -z {{ printf "%s-cassandra" .Release.Name | trunc 63 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
+          command: ['sh', '-c', "until nc -v -z {{ printf "%s-cassandra" .Release.Name | trunc 63 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
           {{- else }}
           command: ['sh', '-c', "until nc -v -z {{ index .Values.database.hostnames 0 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
           {{- end }}
@@ -45,7 +45,7 @@ spec:
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
           {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.index.hostnames) 0) }}
-          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ printf "%s-elasticsearch" .Release.Name | trunc 63 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
+          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ printf "%s-elasticsearch" .Release.Name | trunc 63 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
           {{- else }}
           command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.index.hostnames 0 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
           {{- end }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -36,11 +36,19 @@ spec:
         - name: init-cassandra
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
-          command: ['sh', '-c', "until nslookup {{ index .Values.database.hostnames 0 }}{{ if .Values.cassandra.enabled }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc{{ if .Values.clusterDomain }}.{{ .Values.clusterDomain }}{{ end }}{{ end }}; do echo waiting for cassandra; sleep 2; done"]
-        - name: init-elastic
+          {{- if and (.Values.cassandra.enabled) (eq (len .Values.database.hostnames) 0) }}
+          command: ['sh', '-c', "until nc -v -z {{ printf "%s-cassandra" .Release.Name | trunc 63 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
+          {{- else }}
+          command: ['sh', '-c', "until nc -v -z {{ index .Values.database.hostnames 0 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
+          {{- end }}
+        - name: init-elasticsearch
           image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
-          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.index.hostnames 0 }}{{ if .Values.elasticsearch.enabled }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc{{ if .Values.clusterDomain }}.{{ .Values.clusterDomain }}{{ end }}{{ end }}:{{ .Values.index.port }}/_cluster/health ; do echo waiting for elasticsearch; sleep 2; done"]
+          {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.index.hostnames) 0) }}
+          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ printf "%s-elasticsearch" .Release.Name | trunc 63 }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
+          {{- else }}
+          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.index.hostnames 0 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
+          {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -5,9 +5,6 @@
 nameOverride: ""
 fullnameOverride: ""
 
-# The k8s cluster's domain
-clusterDomain: "cluster.local"
-
 # TheHive image
 image:
   registry: docker.io
@@ -54,10 +51,11 @@ database:
   # The name of an existing k8s secret containing Cassandra password
   k8sSecretName: ""
   k8sSecretKey: "cassandra-password"
-  # List of Cassandra cluster hostnames
-  hostnames:
-    - "thehive-cassandra"
-  # Set to true to wait 30 seconds for Cassandra to start before launching TheHive
+  # List of Cassandra hostnames
+  # Automatically set to Cassandra dependency chart service if enabled and this list is empty
+  hostnames: []
+    #- "mycassandra.example.com"
+  # Set to true for TheHive to wait 30 seconds before starting the app
   wait: false
 
 # TheHive ElasticSearch configuration
@@ -69,11 +67,10 @@ index:
   # The name of an existing k8s secret containing ElasticSearch password
   k8sSecretName: ""
   k8sSecretKey: "elasticsearch-password"
-  # List of ElasticSearch cluster hostnames
-  hostnames:
-    - "thehive-elasticsearch"
-  # ElasticSearch API port
-  port: "9200"
+  # List of ElasticSearch hostnames
+  # Automatically set to ElasticSearch dependency chart service if enabled and this list is empty
+  hostnames: []
+    #- "myelasticsearch.example.com"
 
 # TheHive object storage configuration
 storage:

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -52,7 +52,7 @@ database:
   k8sSecretName: ""
   k8sSecretKey: "cassandra-password"
   # List of Cassandra hostnames
-  # Automatically set to Cassandra dependency chart service if enabled and this list is empty
+  # Auto set to Cassandra subchart service if enabled and this list is empty: "{{ .Release.Name }}-cassandra"
   hostnames: []
     #- "mycassandra.example.com"
   # Set to true for TheHive to wait 30 seconds before starting the app
@@ -68,7 +68,7 @@ index:
   k8sSecretName: ""
   k8sSecretKey: "elasticsearch-password"
   # List of ElasticSearch hostnames
-  # Automatically set to ElasticSearch dependency chart service if enabled and this list is empty
+  # Auto set to ElasticSearch subchart service if enabled and this list is empty: "{{ .Release.Name }}-elasticsearch"
   hostnames: []
     #- "myelasticsearch.example.com"
 
@@ -82,7 +82,8 @@ storage:
   k8sSecretName: ""
   k8sSecretKey: "rootPassword"
   # Bucket information
-  endpoint: "http://thehive-minio:9000"
+  # Auto set to MinIO subchart service if enabled and this string is empty: "http://{{ .Release.Name }}-minio:9000"
+  endpoint: ""
   bucket: "thehive"
   region: "us-east-1"
   usePathAccessStyle: true


### PR DESCRIPTION
Changes summary:
- Take `.Release.Name` in account when targeting k8s services from subcharts
- Remove `clusterDomain` variable and rely on k8s internal DNS to resolve services in the same namespace
- Use netcat instead of nslookup in initContainers because of [a bug in busybox recent releases](https://github.com/docker-library/busybox/issues/48)
- Remove ElasticSearch port variable and assume `9200` as the default API port