### PR TITLE
Create dedicated templates for TheHive Role and RoleBinding manifests

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - Improve subchart services hostnames handling [#43](https://github.com/StrangeBeeCorp/helm-charts/pull/43)
+- Create dedicated templates for TheHive Role and RoleBinding manifests [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/templates/role.yaml
+++ b/thehive-charts/thehive/templates/role.yaml
@@ -1,0 +1,10 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "thehive.serviceAccountName" . }}-pod-reader
+  labels:
+    {{- include "thehive.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]

--- a/thehive-charts/thehive/templates/rolebinding.yaml
+++ b/thehive-charts/thehive/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "thehive.serviceAccountName" . }}-pod-reader-binding
+  labels:
+    {{- include "thehive.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "thehive.serviceAccountName" . }}
+roleRef:
+  kind: Role
+  name: {{ include "thehive.serviceAccountName" . }}-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/thehive-charts/thehive/templates/serviceaccount.yaml
+++ b/thehive-charts/thehive/templates/serviceaccount.yaml
@@ -12,18 +12,6 @@ metadata:
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 
 ---
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "thehive.serviceAccountName" . }}-pod-reader
-  labels:
-    {{- include "thehive.labels" . | nindent 4 }}
-rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "watch", "list"]
-
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/thehive-charts/thehive/templates/serviceaccount.yaml
+++ b/thehive-charts/thehive/templates/serviceaccount.yaml
@@ -10,19 +10,3 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "thehive.serviceAccountName" . }}-pod-reader-binding
-  labels:
-    {{- include "thehive.labels" . | nindent 4 }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "thehive.serviceAccountName" . }}
-roleRef:
-  kind: Role
-  name: {{ include "thehive.serviceAccountName" . }}-pod-reader
-  apiGroup: rbac.authorization.k8s.io
-{{- end }}


### PR DESCRIPTION
Changes summary:
- Move TheHive `Role` template out of the `ServiceAccount` template
- Move TheHive `RoleBinding` template out of the `ServiceAccount` template