### PR TITLE
(BREAKING CHANGE) Change initContainers config and values

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Improve subchart services hostnames handling [#43](https://github.com/StrangeBeeCorp/helm-charts/pull/43)
 - Create dedicated templates for TheHive Role and RoleBinding manifests [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44)
+- (BREAKING CHANGE) Change initContainers config and values [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -30,25 +30,29 @@ spec:
       serviceAccountName: {{ include "thehive.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{ if .Values.useInitContainers }}
+      {{ if or .Values.initContainers.checkCassandra.enabled .Values.initContainers.checkElasticsearch.enabled }}
       # See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#init-containers-in-use
       initContainers:
-        - name: init-cassandra
-          image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
-          imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
+        {{ if .Values.initContainers.checkCassandra.enabled }}
+        - name: check-cassandra
+          image: "{{ .Values.initContainers.image.registry }}/{{ .Values.initContainers.image.repository }}:{{ .Values.initContainers.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.image.pullPolicy }}
           {{- if and (.Values.cassandra.enabled) (eq (len .Values.database.hostnames) 0) }}
           command: ['sh', '-c', "until nc -v -z {{ printf "%s-cassandra" .Release.Name | trunc 63 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
           {{- else }}
           command: ['sh', '-c', "until nc -v -z {{ index .Values.database.hostnames 0 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
           {{- end }}
-        - name: init-elasticsearch
-          image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
-          imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
+        {{- end }}
+        {{ if .Values.initContainers.checkElasticsearch.enabled }}
+        - name: check-elasticsearch
+          image: "{{ .Values.initContainers.image.registry }}/{{ .Values.initContainers.image.repository }}:{{ .Values.initContainers.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.image.pullPolicy }}
           {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.index.hostnames) 0) }}
           command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ printf "%s-elasticsearch" .Release.Name | trunc 63 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
           {{- else }}
           command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.index.hostnames 0 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
           {{- end }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -89,15 +89,20 @@ storage:
   usePathAccessStyle: true
 
 # Add init containers to TheHive deployment (to wait for Cassandra and ElasticSearch to be reachable)
-useInitContainers: true
-
-# Busybox image (used by initContainers)
-busybox:
+initContainers:
   image:
     registry: docker.io
     repository: busybox
     tag: "1.36.1-glibc"
     pullPolicy: IfNotPresent
+
+  # Wait for Cassandra to be reachable on port 9042
+  checkCassandra:
+    enabled: true
+
+  # Wait for ElasticSearch "/_cluster/health" route on port 9200 to answer
+  checkElasticsearch:
+    enabled: true
 
 # TheHive HTTP secret
 httpSecret: ""


### PR DESCRIPTION
Changes summary:
- (BREAKING CHANGE) Change `useInitContainers` boolean key to a more complex `initContainers` object in `values.yaml`
- Allow users to enable only one of the two initContainers
- Change ambiguous initContainers names by changing `init-` prefix with `check-`
- Move `busybox` image variables to the new `initContainers` object