### PR TITLE
Add parameters in TheHive values.yaml to configure Cortex servers

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Improve subchart services hostnames handling [#43](https://github.com/StrangeBeeCorp/helm-charts/pull/43)
 - Create dedicated templates for TheHive Role and RoleBinding manifests [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44)
 - (BREAKING CHANGE) Change initContainers config and values [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45)
+- Add parameters in TheHive values.yaml to configure Cortex servers [#46](https://github.com/StrangeBeeCorp/helm-charts/pull/46)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -104,3 +104,26 @@ However, we recommend that you use a managed object storage service to guarantee
 - [GCP Cloud Storage](https://cloud.google.com/storage)
 
 Do note that [network shared filesystem (e.g. NFS)](https://docs.strangebee.com/thehive/installation/deploying-a-cluster/#file-storage) is supported too, but it can be trickier to implement and slower.
+
+
+### Cortex
+
+No Cortex server is defined in TheHive configuration by default.
+
+There are multiple ways to add Cortex servers to TheHive, among them:
+- [Add it from TheHive UI](https://docs.strangebee.com/thehive/administration/cortex/)
+- Add Cortex information in the related `values.yaml` object
+
+For the latter, here is an example:
+```yaml
+cortex:
+  enabled: true
+  protocol: "http"
+  hostnames:
+    - "cortex.default.svc" # Assuming cortex is deployed in the "default" namespace
+  port: 9001
+  api_keys:
+    - "<insert_cortex_api_key_here>" # Or even better, use an existing secret using the parameters below
+  #k8sSecretName: ""
+  #k8sSecretKey: "api-keys"
+```

--- a/thehive-charts/thehive/templates/configmap-env.yaml
+++ b/thehive-charts/thehive/templates/configmap-env.yaml
@@ -26,10 +26,10 @@ data:
   TH_S3_BUCKET: {{ .Values.storage.bucket | quote }}
   TH_S3_REGION: {{ .Values.storage.region | quote }}
   {{- if .Values.cortex.enabled }}
-  TH_NO_CONFIG_CORTEX: 0
+  TH_NO_CONFIG_CORTEX: "0"
   TH_CORTEX_PROTO: {{ .Values.cortex.protocol | quote }}
   TH_CORTEX_HOSTNAMES: {{ join "," .Values.cortex.hostnames | quote }}
   TH_CORTEX_PORT: {{ .Values.cortex.port | quote }}
   {{- else }}
-  TH_NO_CONFIG_CORTEX: 1
+  TH_NO_CONFIG_CORTEX: "1"
   {{- end }}

--- a/thehive-charts/thehive/templates/configmap-env.yaml
+++ b/thehive-charts/thehive/templates/configmap-env.yaml
@@ -25,3 +25,11 @@ data:
   {{- end }}
   TH_S3_BUCKET: {{ .Values.storage.bucket | quote }}
   TH_S3_REGION: {{ .Values.storage.region | quote }}
+  {{- if .Values.cortex.enabled }}
+  TH_NO_CONFIG_CORTEX: 0
+  TH_CORTEX_PROTO: {{ .Values.cortex.protocol | quote }}
+  TH_CORTEX_HOSTNAMES: {{ join "," .Values.cortex.hostnames | quote }}
+  TH_CORTEX_PORT: {{ .Values.cortex.port | quote }}
+  {{- else }}
+  TH_NO_CONFIG_CORTEX: 1
+  {{- end }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -65,7 +65,6 @@ spec:
             - "--kubernetes"
             - "--kubernetes-pod-label-selector"
             - "app.kubernetes.io/name={{ include "thehive.name" . }}"
-            {{ if not .Values.cortex.enabled -}}- "--no-config-cortex"{{- end }}
             {{ if not .Values.database.wait -}}- "--no-cql-wait"{{- end }}
             - "--index-backend"
             - "elasticsearch"
@@ -112,6 +111,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.k8sSecretName }}
                   key: {{ .Values.k8sSecretKey }}
+            {{- end }}
+            {{- if .Values.cortex.k8sSecretName }}
+            - name: TH_CORTEX_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cortex.k8sSecretName }}
+                  key: {{ .Values.cortex.k8sSecretKey }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/thehive-charts/thehive/templates/secrets.yaml
+++ b/thehive-charts/thehive/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.database.k8sSecretName) (not .Values.index.k8sSecretName) (not .Values.storage.k8sSecretName) (not .Values.k8sSecretName) }}
+{{- if or (not .Values.database.k8sSecretName) (not .Values.index.k8sSecretName) (not .Values.storage.k8sSecretName) (not .Values.k8sSecretName) (and (.Values.cortex.enabled) (not .Values.cortex.k8sSecretName)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,5 +18,8 @@ data:
   {{- end }}
   {{- if not .Values.k8sSecretName }}
   TH_SECRET: {{ .Values.httpSecret | b64enc | quote }}
+  {{- end }}
+  {{- if and (.Values.cortex.enabled) (not .Values.cortex.k8sSecretName) }}
+  TH_CORTEX_KEYS: {{ join "," .Values.cortex.api_keys | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -123,7 +123,7 @@ cortex:
   # Cortex API keys
   # Each API key will be mapped to a single Cortex hostname (following the order in this YAML)
   api_keys: []
-    #- "<api_key_for_mycortex>"
+    #- "abcdefghijklmnopqrstuvwxyz012345"
   # Alternatively, the name of an existing k8s secret containing all API keys for TheHive to connect to Cortex servers
   # Expected format: "<key>,<key>,..."
   k8sSecretName: ""

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -110,9 +110,24 @@ httpSecret: ""
 k8sSecretName: ""
 k8sSecretKey: "http-secret"
 
-# Cortex configuration (not implemented yet)
+# Cortex configuration
+# You can also add Cortex servers directly from TheHive UI https://docs.strangebee.com/thehive/administration/cortex/
 cortex:
   enabled: false
+  # Cortex protocol (expected values are "http" or "https")
+  protocol: "http"
+  # List of Cortex hostnames to configure
+  hostnames: []
+    #- "mycortex.example.com"
+  port: 9001
+  # Cortex API keys
+  # Each API key will be mapped to a single Cortex hostname (following the order in this YAML)
+  api_keys: []
+    #- "<api_key_for_mycortex>"
+  # Alternatively, the name of an existing k8s secret containing all API keys for TheHive to connect to Cortex servers
+  # Expected format: "<key>,<key>,..."
+  k8sSecretName: ""
+  k8sSecretKey: "api-keys"
 
 # Custom application.conf file for TheHive (included on startup)
 extraConfig: ""


### PR DESCRIPTION
Changes summary:
- Add parameters in TheHive `values.yaml` to configure Cortex servers
- Document Cortex configuration and some caveats related to ElasticSearch version
- Replace `--no-config-cortex` command flag with `TH_NO_CONFIG_CORTEX` environment variable