### PR TITLE
Fix regressions introduced in #44 and #45

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Create dedicated templates for TheHive Role and RoleBinding manifests [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44)
 - (BREAKING CHANGE) Change initContainers config and values [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45)
 - Add parameters in TheHive values.yaml to configure Cortex servers [#46](https://github.com/StrangeBeeCorp/helm-charts/pull/46)
+- Fix regressions introduced in [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44) and [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45) [#47](https://github.com/StrangeBeeCorp/helm-charts/pull/47)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -30,10 +30,10 @@ spec:
       serviceAccountName: {{ include "thehive.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{ if or .Values.initContainers.checkCassandra.enabled .Values.initContainers.checkElasticsearch.enabled }}
+      {{- if or .Values.initContainers.checkCassandra.enabled .Values.initContainers.checkElasticsearch.enabled }}
       # See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#init-containers-in-use
       initContainers:
-        {{ if .Values.initContainers.checkCassandra.enabled }}
+        {{- if .Values.initContainers.checkCassandra.enabled }}
         - name: check-cassandra
           image: "{{ .Values.initContainers.image.registry }}/{{ .Values.initContainers.image.repository }}:{{ .Values.initContainers.image.tag }}"
           imagePullPolicy: {{ .Values.initContainers.image.pullPolicy }}
@@ -43,7 +43,7 @@ spec:
           command: ['sh', '-c', "until nc -v -z {{ index .Values.database.hostnames 0 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
           {{- end }}
         {{- end }}
-        {{ if .Values.initContainers.checkElasticsearch.enabled }}
+        {{- if .Values.initContainers.checkElasticsearch.enabled }}
         - name: check-elasticsearch
           image: "{{ .Values.initContainers.image.registry }}/{{ .Values.initContainers.image.repository }}:{{ .Values.initContainers.image.tag }}"
           imagePullPolicy: {{ .Values.initContainers.image.pullPolicy }}

--- a/thehive-charts/thehive/templates/role.yaml
+++ b/thehive-charts/thehive/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -8,3 +9,4 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "watch", "list"]
+{{- end }}

--- a/thehive-charts/thehive/templates/rolebinding.yaml
+++ b/thehive-charts/thehive/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/thehive-charts/thehive/templates/serviceaccount.yaml
+++ b/thehive-charts/thehive/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,3 +10,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}


### PR DESCRIPTION
Changes summary:
- Add missing `if` and `end` blocks in the `ServiceAccount`, `Role` and `RoleBinding` templates (related to #44)
- Add missing `-` in `if` blocks introduced by #45 for the new `initContainers` configuration