### PR TITLE
Add probe configs and update TheHive healthcheck route

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -5,6 +5,7 @@
 - (BREAKING CHANGE) Change initContainers config and values [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45)
 - Add parameters in TheHive values.yaml to configure Cortex servers [#46](https://github.com/StrangeBeeCorp/helm-charts/pull/46)
 - Fix regressions introduced in [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44) and [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45) [#47](https://github.com/StrangeBeeCorp/helm-charts/pull/47)
+- Add probe configs and update TheHive healthcheck route [#48](https://github.com/StrangeBeeCorp/helm-charts/pull/48)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -142,7 +142,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/status
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -152,7 +152,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/status
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -134,20 +134,31 @@ spec:
           startupProbe:
             tcpSocket:
               port: http
-            failureThreshold: 36
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -153,17 +153,30 @@ extraEnv: []
   #      name: "cm-name"
   #      key: "key-name"
 
-# Startup probe
+# Startup probe (set "failureThreshold" to a high value to prevent CrashLoops during schema migrations)
 startupProbe:
   enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 5
+  timeoutSeconds: 1
+  failureThreshold: 36
 
 # Liveness probe
 livenessProbe:
   enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
 
 # Readiness probe
 readinessProbe:
   enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
 
 serviceAccount:
   # Create a ServiceAccount for TheHive


### PR DESCRIPTION
Changes summary:
- Add `startupProbe`, `livenessProbe` and  `readinessProbe` configs
- Change healthcheck route from `/` to `/api/status`