### PR TITLE
(BREAKING CHANGE) Add "thehive" root key and rename application.conf variable

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add parameters in TheHive values.yaml to configure Cortex servers [#46](https://github.com/StrangeBeeCorp/helm-charts/pull/46)
 - Fix regressions introduced in [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44) and [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45) [#47](https://github.com/StrangeBeeCorp/helm-charts/pull/47)
 - Add probe configs and update TheHive healthcheck route [#48](https://github.com/StrangeBeeCorp/helm-charts/pull/48)
+- (BREAKING CHANGE) Add "thehive" root key and rename application.conf variable [#49](https://github.com/StrangeBeeCorp/helm-charts/pull/49)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/templates/_helpers.tpl
+++ b/thehive-charts/thehive/templates/_helpers.tpl
@@ -43,11 +43,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "thehive.labels" -}}
 {{ include "thehive.commonLabels" . }}
 {{ include "thehive.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.thehive.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/component: "frontend"
 {{- end }}
 
 {{/* TheHive service account name */}}
 {{- define "thehive.serviceAccountName" -}}
-{{- default (include "thehive.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "thehive.fullname" .) .Values.thehive.serviceAccount.name }}
 {{- end }}

--- a/thehive-charts/thehive/templates/configmap-env.yaml
+++ b/thehive-charts/thehive/templates/configmap-env.yaml
@@ -5,31 +5,31 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:
-  TH_CQL_USERNAME: {{ .Values.database.username | quote }}
-  {{- if and (.Values.cassandra.enabled) (eq (len .Values.database.hostnames) 0) }}
+  TH_CQL_USERNAME: {{ .Values.thehive.database.username | quote }}
+  {{- if and (.Values.cassandra.enabled) (eq (len .Values.thehive.database.hostnames) 0) }}
   TH_CQL_HOSTNAMES: {{ printf "%s-cassandra" .Release.Name | trunc 63 | quote }}
   {{- else }}
-  TH_CQL_HOSTNAMES: {{ join "," .Values.database.hostnames | quote }}
+  TH_CQL_HOSTNAMES: {{ join "," .Values.thehive.database.hostnames | quote }}
   {{- end }}
-  TH_ELASTICSEARCH_USERNAME: {{ .Values.index.username | quote }}
-  {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.index.hostnames) 0) }}
+  TH_ELASTICSEARCH_USERNAME: {{ .Values.thehive.index.username | quote }}
+  {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.thehive.index.hostnames) 0) }}
   TH_ELASTICSEARCH_HOSTNAMES: {{ printf "%s-elasticsearch" .Release.Name | trunc 63 | quote }}
   {{- else }}
-  TH_ELASTICSEARCH_HOSTNAMES: {{ join "," .Values.index.hostnames | quote }}
+  TH_ELASTICSEARCH_HOSTNAMES: {{ join "," .Values.thehive.index.hostnames | quote }}
   {{- end }}
-  TH_S3_ACCESS_KEY: {{ .Values.storage.accessKey | quote }}
-  {{- if and (.Values.minio.enabled) (empty .Values.storage.endpoint) }}
+  TH_S3_ACCESS_KEY: {{ .Values.thehive.storage.accessKey | quote }}
+  {{- if and (.Values.minio.enabled) (empty .Values.thehive.storage.endpoint) }}
   TH_S3_ENDPOINT: {{ printf "http://%s-minio:9000" .Release.Name | quote }}
   {{- else }}
-  TH_S3_ENDPOINT: {{ .Values.storage.endpoint | quote }}
+  TH_S3_ENDPOINT: {{ .Values.thehive.storage.endpoint | quote }}
   {{- end }}
-  TH_S3_BUCKET: {{ .Values.storage.bucket | quote }}
-  TH_S3_REGION: {{ .Values.storage.region | quote }}
-  {{- if .Values.cortex.enabled }}
+  TH_S3_BUCKET: {{ .Values.thehive.storage.bucket | quote }}
+  TH_S3_REGION: {{ .Values.thehive.storage.region | quote }}
+  {{- if .Values.thehive.cortex.enabled }}
   TH_NO_CONFIG_CORTEX: "0"
-  TH_CORTEX_PROTO: {{ .Values.cortex.protocol | quote }}
-  TH_CORTEX_HOSTNAMES: {{ join "," .Values.cortex.hostnames | quote }}
-  TH_CORTEX_PORT: {{ .Values.cortex.port | quote }}
+  TH_CORTEX_PROTO: {{ .Values.thehive.cortex.protocol | quote }}
+  TH_CORTEX_HOSTNAMES: {{ join "," .Values.thehive.cortex.hostnames | quote }}
+  TH_CORTEX_PORT: {{ .Values.thehive.cortex.port | quote }}
   {{- else }}
   TH_NO_CONFIG_CORTEX: "1"
   {{- end }}

--- a/thehive-charts/thehive/templates/configmap-file.yaml
+++ b/thehive-charts/thehive/templates/configmap-file.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.thehive.extraConfig }}
+{{- if .Values.thehive.applicationConf }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:
-  application.conf: {{- .Values.thehive.extraConfig | toYaml | indent 1 }}
+  application.conf: {{- .Values.thehive.applicationConf | toYaml | indent 1 }}
 {{- end }}

--- a/thehive-charts/thehive/templates/configmap-file.yaml
+++ b/thehive-charts/thehive/templates/configmap-file.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.extraConfig  }}
+{{- if .Values.thehive.extraConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:
-  application.conf: {{- .Values.extraConfig | toYaml | indent 1 }}
-{{- end -}}
+  application.conf: {{- .Values.thehive.extraConfig | toYaml | indent 1 }}
+{{- end }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -5,21 +5,21 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  {{- if not .Values.thehive.autoscaling.enabled }}
+  replicas: {{ .Values.thehive.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "thehive.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.thehive.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "thehive.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
+        {{- with .Values.thehive.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -29,100 +29,100 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "thehive.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if or .Values.initContainers.checkCassandra.enabled .Values.initContainers.checkElasticsearch.enabled }}
+        {{- toYaml .Values.thehive.podSecurityContext | nindent 8 }}
+      {{- if or .Values.thehive.initContainers.checkCassandra.enabled .Values.thehive.initContainers.checkElasticsearch.enabled }}
       # See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#init-containers-in-use
       initContainers:
-        {{- if .Values.initContainers.checkCassandra.enabled }}
+        {{- if .Values.thehive.initContainers.checkCassandra.enabled }}
         - name: check-cassandra
-          image: "{{ .Values.initContainers.image.registry }}/{{ .Values.initContainers.image.repository }}:{{ .Values.initContainers.image.tag }}"
-          imagePullPolicy: {{ .Values.initContainers.image.pullPolicy }}
-          {{- if and (.Values.cassandra.enabled) (eq (len .Values.database.hostnames) 0) }}
+          image: "{{ .Values.thehive.initContainers.image.registry }}/{{ .Values.thehive.initContainers.image.repository }}:{{ .Values.thehive.initContainers.image.tag }}"
+          imagePullPolicy: {{ .Values.thehive.initContainers.image.pullPolicy }}
+          {{- if and (.Values.cassandra.enabled) (eq (len .Values.thehive.database.hostnames) 0) }}
           command: ['sh', '-c', "until nc -v -z {{ printf "%s-cassandra" .Release.Name | trunc 63 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
           {{- else }}
-          command: ['sh', '-c', "until nc -v -z {{ index .Values.database.hostnames 0 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
+          command: ['sh', '-c', "until nc -v -z {{ index .Values.thehive.database.hostnames 0 }} 9042; do echo 'Waiting for Cassandra'; sleep 5; done"]
           {{- end }}
         {{- end }}
-        {{- if .Values.initContainers.checkElasticsearch.enabled }}
+        {{- if .Values.thehive.initContainers.checkElasticsearch.enabled }}
         - name: check-elasticsearch
-          image: "{{ .Values.initContainers.image.registry }}/{{ .Values.initContainers.image.repository }}:{{ .Values.initContainers.image.tag }}"
-          imagePullPolicy: {{ .Values.initContainers.image.pullPolicy }}
-          {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.index.hostnames) 0) }}
+          image: "{{ .Values.thehive.initContainers.image.registry }}/{{ .Values.thehive.initContainers.image.repository }}:{{ .Values.thehive.initContainers.image.tag }}"
+          imagePullPolicy: {{ .Values.thehive.initContainers.image.pullPolicy }}
+          {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.thehive.index.hostnames) 0) }}
           command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ printf "%s-elasticsearch" .Release.Name | trunc 63 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
           {{- else }}
-          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.index.hostnames 0 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
+          command: ['sh', '-c', "until wget --no-cache --no-check-certificate --spider http://{{ index .Values.thehive.index.hostnames 0 }}:9200/_cluster/health; do echo 'Waiting for ElasticSearch'; sleep 5; done"]
           {{- end }}
         {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- toYaml .Values.thehive.securityContext | nindent 12 }}
+          image: "{{ .Values.thehive.image.registry }}/{{ .Values.thehive.image.repository }}:{{ .Values.thehive.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.thehive.image.pullPolicy }}
           command:
             - "/opt/thehive/entrypoint"
             - "--kubernetes"
             - "--kubernetes-pod-label-selector"
             - "app.kubernetes.io/name={{ include "thehive.name" . }}"
-            {{ if not .Values.database.wait -}}- "--no-cql-wait"{{- end }}
+            {{ if not .Values.thehive.database.wait -}}- "--no-cql-wait"{{- end }}
             - "--index-backend"
             - "elasticsearch"
-            {{ if .Values.storage.usePathAccessStyle -}}- "--s3-use-path-access-style"{{- end }}
+            {{ if .Values.thehive.storage.usePathAccessStyle -}}- "--s3-use-path-access-style"{{- end }}
             - "--cluster-min-nodes-count"
-            - "{{ .Values.clusterMinNodesCount }}"
-          {{- with .Values.extraCommand }}
+            - "{{ .Values.thehive.clusterMinNodesCount }}"
+          {{- with .Values.thehive.extraCommand }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.extraEnv }}
-            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- if .Values.thehive.extraEnv }}
+            {{- toYaml .Values.thehive.extraEnv | nindent 12 }}
             {{- end }}
             - name: JVM_OPTS
-              value: {{ .Values.jvmOpts | quote }}
+              value: {{ .Values.thehive.jvmOpts | quote }}
             - name: POD_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            {{- if .Values.database.k8sSecretName }}
+            {{- if .Values.thehive.database.k8sSecretName }}
             - name: TH_CQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.database.k8sSecretName }}
-                  key: {{ .Values.database.k8sSecretKey }}
+                  name: {{ .Values.thehive.database.k8sSecretName }}
+                  key: {{ .Values.thehive.database.k8sSecretKey }}
             {{- end }}
-            {{- if .Values.index.k8sSecretName }}
+            {{- if .Values.thehive.index.k8sSecretName }}
             - name: TH_ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.index.k8sSecretName }}
-                  key: {{ .Values.index.k8sSecretKey }}
+                  name: {{ .Values.thehive.index.k8sSecretName }}
+                  key: {{ .Values.thehive.index.k8sSecretKey }}
             {{- end }}
-            {{- if .Values.storage.k8sSecretName }}
+            {{- if .Values.thehive.storage.k8sSecretName }}
             - name: TH_S3_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.storage.k8sSecretName }}
-                  key: {{ .Values.storage.k8sSecretKey }}
+                  name: {{ .Values.thehive.storage.k8sSecretName }}
+                  key: {{ .Values.thehive.storage.k8sSecretKey }}
             {{- end }}
-            {{- if .Values.k8sSecretName }}
+            {{- if .Values.thehive.k8sSecretName }}
             - name: TH_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.k8sSecretName }}
-                  key: {{ .Values.k8sSecretKey }}
+                  name: {{ .Values.thehive.k8sSecretName }}
+                  key: {{ .Values.thehive.k8sSecretKey }}
             {{- end }}
-            {{- if .Values.cortex.k8sSecretName }}
+            {{- if .Values.thehive.cortex.k8sSecretName }}
             - name: TH_CORTEX_KEYS
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.cortex.k8sSecretName }}
-                  key: {{ .Values.cortex.k8sSecretKey }}
+                  name: {{ .Values.thehive.cortex.k8sSecretName }}
+                  key: {{ .Values.thehive.cortex.k8sSecretKey }}
             {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "thehive.fullname" . }}-env
-            {{- if or (not .Values.database.k8sSecretName) (not .Values.index.k8sSecretName) (not .Values.storage.k8sSecretName) (not .Values.k8sSecretName) }}
+            {{- if or (not .Values.thehive.database.k8sSecretName) (not .Values.thehive.index.k8sSecretName) (not .Values.thehive.storage.k8sSecretName) (not .Values.thehive.k8sSecretName) }}
             - secretRef:
                 name: {{ include "thehive.fullname" . }}-secrets
             {{- end }}
@@ -130,70 +130,70 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
-          {{- if .Values.startupProbe.enabled }}
+          {{- if .Values.thehive.startupProbe.enabled }}
           startupProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.thehive.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.thehive.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.thehive.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.thehive.startupProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.livenessProbe.enabled }}
+          {{- if .Values.thehive.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/status
               port: http
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.thehive.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.thehive.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.thehive.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.thehive.livenessProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+          {{- if .Values.thehive.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/status
               port: http
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.thehive.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.thehive.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.thehive.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.thehive.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.thehive.readinessProbe.failureThreshold }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.volumeMounts .Values.extraConfig }}
+            {{- toYaml .Values.thehive.resources | nindent 12 }}
+          {{- if or .Values.thehive.volumeMounts .Values.thehive.extraConfig }}
           volumeMounts:
-          {{- if .Values.extraConfig }}
+          {{- if .Values.thehive.extraConfig }}
             - name: config
               mountPath: /etc/thehive/application.conf
               subPath: application.conf
               readOnly: true
           {{- end -}}
-          {{- with .Values.volumeMounts }}
+          {{- with .Values.thehive.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
-      {{- if or .Values.volumes .Values.extraConfig }}
+      {{- if or .Values.thehive.volumes .Values.thehive.extraConfig }}
       volumes:
-      {{- if .Values.extraConfig }}
+      {{- if .Values.thehive.extraConfig }}
         - name: config
           configMap:
             name: {{ include "thehive.fullname" . }}-config
       {{- end -}}
-      {{- with .Values.volumes }}
+      {{- with .Values.thehive.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.thehive.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.thehive.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.thehive.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -162,9 +162,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.thehive.resources | nindent 12 }}
-          {{- if or .Values.thehive.volumeMounts .Values.thehive.extraConfig }}
+          {{- if or .Values.thehive.volumeMounts .Values.thehive.applicationConf }}
           volumeMounts:
-          {{- if .Values.thehive.extraConfig }}
+          {{- if .Values.thehive.applicationConf }}
             - name: config
               mountPath: /etc/thehive/application.conf
               subPath: application.conf
@@ -174,9 +174,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
-      {{- if or .Values.thehive.volumes .Values.thehive.extraConfig }}
+      {{- if or .Values.thehive.volumes .Values.thehive.applicationConf }}
       volumes:
-      {{- if .Values.thehive.extraConfig }}
+      {{- if .Values.thehive.applicationConf }}
         - name: config
           configMap:
             name: {{ include "thehive.fullname" . }}-config

--- a/thehive-charts/thehive/templates/hpa.yaml
+++ b/thehive-charts/thehive/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.thehive.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -10,23 +10,23 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "thehive.fullname" . }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.thehive.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.thehive.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.thehive.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.thehive.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.thehive.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.thehive.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/thehive-charts/thehive/templates/ingress.yaml
+++ b/thehive-charts/thehive/templates/ingress.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.thehive.ingress.enabled -}}
 {{- $fullName := include "thehive.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- $svcPort := .Values.thehive.service.port -}}
+{{- if and .Values.thehive.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.thehive.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.thehive.ingress.annotations "kubernetes.io/ingress.class" .Values.thehive.ingress.className}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -18,17 +18,17 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.thehive.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if and .Values.thehive.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.thehive.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.thehive.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.thehive.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -37,7 +37,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.thehive.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/thehive-charts/thehive/templates/pdb.yaml
+++ b/thehive-charts/thehive/templates/pdb.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 spec:
-  maxUnavailable: {{ .Values.maxUnavailable | default 1 }}
+  maxUnavailable: {{ .Values.thehive.maxUnavailable | default 1 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "thehive.fullname" . }}

--- a/thehive-charts/thehive/templates/role.yaml
+++ b/thehive-charts/thehive/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.thehive.serviceAccount.create }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/thehive-charts/thehive/templates/rolebinding.yaml
+++ b/thehive-charts/thehive/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.thehive.serviceAccount.create }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/thehive-charts/thehive/templates/secrets.yaml
+++ b/thehive-charts/thehive/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.database.k8sSecretName) (not .Values.index.k8sSecretName) (not .Values.storage.k8sSecretName) (not .Values.k8sSecretName) (and (.Values.cortex.enabled) (not .Values.cortex.k8sSecretName)) }}
+{{- if or (not .Values.thehive.database.k8sSecretName) (not .Values.thehive.index.k8sSecretName) (not .Values.thehive.storage.k8sSecretName) (not .Values.thehive.k8sSecretName) (and (.Values.thehive.cortex.enabled) (not .Values.thehive.cortex.k8sSecretName)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,19 +7,19 @@ metadata:
     {{- include "thehive.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if not .Values.database.k8sSecretName }}
-  TH_CQL_PASSWORD: {{ .Values.database.password | b64enc | quote }}
+  {{- if not .Values.thehive.database.k8sSecretName }}
+  TH_CQL_PASSWORD: {{ .Values.thehive.database.password | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.index.k8sSecretName }}
-  TH_ELASTICSEARCH_PASSWORD: {{ .Values.index.password | b64enc | quote }}
+  {{- if not .Values.thehive.index.k8sSecretName }}
+  TH_ELASTICSEARCH_PASSWORD: {{ .Values.thehive.index.password | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.storage.k8sSecretName }}
-  TH_S3_SECRET_KEY: {{ .Values.storage.secretKey | b64enc | quote }}
+  {{- if not .Values.thehive.storage.k8sSecretName }}
+  TH_S3_SECRET_KEY: {{ .Values.thehive.storage.secretKey | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.k8sSecretName }}
-  TH_SECRET: {{ .Values.httpSecret | b64enc | quote }}
+  {{- if not .Values.thehive.k8sSecretName }}
+  TH_SECRET: {{ .Values.thehive.httpSecret | b64enc | quote }}
   {{- end }}
-  {{- if and (.Values.cortex.enabled) (not .Values.cortex.k8sSecretName) }}
-  TH_CORTEX_KEYS: {{ join "," .Values.cortex.api_keys | b64enc | quote }}
+  {{- if and (.Values.thehive.cortex.enabled) (not .Values.thehive.cortex.k8sSecretName) }}
+  TH_CORTEX_KEYS: {{ join "," .Values.thehive.cortex.api_keys | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/thehive-charts/thehive/templates/service.yaml
+++ b/thehive-charts/thehive/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.thehive.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.thehive.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/thehive-charts/thehive/templates/serviceaccount.yaml
+++ b/thehive-charts/thehive/templates/serviceaccount.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.thehive.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "thehive.serviceAccountName" . }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.thehive.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.thehive.serviceAccount.automount }}
 {{- end }}

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -131,8 +131,8 @@ thehive:
     k8sSecretKey: "api-keys"
 
   # Custom application.conf file for TheHive (included on startup)
-  extraConfig: ""
-  #extraConfig: |
+  applicationConf: ""
+  #applicationConf: |
   #  # TheHive configuration file
   #  # See https://docs.strangebee.com/thehive/overview/ under the "Configuration" section
 

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -5,239 +5,240 @@
 nameOverride: ""
 fullnameOverride: ""
 
-# TheHive image
-image:
-  registry: docker.io
-  repository: strangebee/thehive
-  # Defaults to the chart appVersion
-  tag: ""
-  pullPolicy: IfNotPresent
-
 imagePullSecrets: []
 
-replicaCount: 2
-
-# TheHive nodes count
-clusterMinNodesCount: 1
-
-# PodDisruptionBudget configuration
-maxUnavailable: 1
-
-autoscaling:
-  enabled: false
-  minReplicas: 2
-  maxReplicas: 4
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 95
-
-resources:
-  requests:
-    cpu: "1000m"
-    memory: "2048Mi"
-    ephemeral-storage: "4Gi"
-  limits:
-    cpu: "3000m"
-    memory: "3584Mi"
-    ephemeral-storage: "4Gi"
-
-jvmOpts: "-Xms2g -Xmx2g -Xmn300m"
-
-# TheHive Cassandra configuration
-database:
-  # Credentials to connect to Cassandra
-  # They should match the credentials for Cassandra subchart below (if enabled)
-  username: "cassandra"
-  password: "ChangeThisPasswordForCassandra"
-  # The name of an existing k8s secret containing Cassandra password
-  k8sSecretName: ""
-  k8sSecretKey: "cassandra-password"
-  # List of Cassandra hostnames
-  # Auto set to Cassandra subchart service if enabled and this list is empty: "{{ .Release.Name }}-cassandra"
-  hostnames: []
-    #- "mycassandra.example.com"
-  # Set to true for TheHive to wait 30 seconds before starting the app
-  wait: false
-
-# TheHive ElasticSearch configuration
-index:
-  # Credentials to connect to ElasticSearch
-  # They should match the credentials for ElasticSearch subchart below (if enabled)
-  username: "elastic"
-  password: ""
-  # The name of an existing k8s secret containing ElasticSearch password
-  k8sSecretName: ""
-  k8sSecretKey: "elasticsearch-password"
-  # List of ElasticSearch hostnames
-  # Auto set to ElasticSearch subchart service if enabled and this list is empty: "{{ .Release.Name }}-elasticsearch"
-  hostnames: []
-    #- "myelasticsearch.example.com"
-
-# TheHive object storage configuration
-storage:
-  # Credentials to connect to the object storage
-  # They should match the credentials for MinIO subchart below (if enabled)
-  accessKey: "minio"
-  secretKey: "ChangeThisPasswordForMinIO"
-  # The name of an existing k8s secret containing the object storage secret key
-  k8sSecretName: ""
-  k8sSecretKey: "rootPassword"
-  # Bucket information
-  # Auto set to MinIO subchart service if enabled and this string is empty: "http://{{ .Release.Name }}-minio:9000"
-  endpoint: ""
-  bucket: "thehive"
-  region: "us-east-1"
-  usePathAccessStyle: true
-
-# Add init containers to TheHive deployment (to wait for Cassandra and ElasticSearch to be reachable)
-initContainers:
+thehive:
+  # TheHive image
   image:
     registry: docker.io
-    repository: busybox
-    tag: "1.36.1-glibc"
+    repository: strangebee/thehive
+    # Defaults to the chart appVersion
+    tag: ""
     pullPolicy: IfNotPresent
 
-  # Wait for Cassandra to be reachable on port 9042
-  checkCassandra:
-    enabled: true
+  replicaCount: 2
 
-  # Wait for ElasticSearch "/_cluster/health" route on port 9200 to answer
-  checkElasticsearch:
-    enabled: true
+  # TheHive nodes count
+  clusterMinNodesCount: 1
 
-# TheHive HTTP secret
-httpSecret: ""
-# The name of an existing k8s secret containing the HTTP secret used by TheHive
-k8sSecretName: ""
-k8sSecretKey: "http-secret"
+  # PodDisruptionBudget configuration
+  maxUnavailable: 1
 
-# Cortex configuration
-# You can also add Cortex servers directly from TheHive UI https://docs.strangebee.com/thehive/administration/cortex/
-cortex:
-  enabled: false
-  # Cortex protocol (expected values are "http" or "https")
-  protocol: "http"
-  # List of Cortex hostnames to configure
-  hostnames: []
-    #- "mycortex.example.com"
-  port: 9001
-  # Cortex API keys
-  # Each API key will be mapped to a single Cortex hostname (following the order in this YAML)
-  api_keys: []
-    #- "abcdefghijklmnopqrstuvwxyz012345"
-  # Alternatively, the name of an existing k8s secret containing all API keys for TheHive to connect to Cortex servers
-  # Expected format: "<key>,<key>,..."
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 95
+
+  resources:
+    requests:
+      cpu: "1000m"
+      memory: "2048Mi"
+      ephemeral-storage: "4Gi"
+    limits:
+      cpu: "3000m"
+      memory: "3584Mi"
+      ephemeral-storage: "4Gi"
+
+  jvmOpts: "-Xms2g -Xmx2g -Xmn300m"
+
+  # TheHive Cassandra configuration
+  database:
+    # Credentials to connect to Cassandra
+    # They should match the credentials for Cassandra subchart below (if enabled)
+    username: "cassandra"
+    password: "ChangeThisPasswordForCassandra"
+    # The name of an existing k8s secret containing Cassandra password
+    k8sSecretName: ""
+    k8sSecretKey: "cassandra-password"
+    # List of Cassandra hostnames
+    # Auto set to Cassandra subchart service if enabled and this list is empty: "{{ .Release.Name }}-cassandra"
+    hostnames: []
+      #- "mycassandra.example.com"
+    # Set to true for TheHive to wait 30 seconds before starting the app
+    wait: false
+
+  # TheHive ElasticSearch configuration
+  index:
+    # Credentials to connect to ElasticSearch
+    # They should match the credentials for ElasticSearch subchart below (if enabled)
+    username: "elastic"
+    password: ""
+    # The name of an existing k8s secret containing ElasticSearch password
+    k8sSecretName: ""
+    k8sSecretKey: "elasticsearch-password"
+    # List of ElasticSearch hostnames
+    # Auto set to ElasticSearch subchart service if enabled and this list is empty: "{{ .Release.Name }}-elasticsearch"
+    hostnames: []
+      #- "myelasticsearch.example.com"
+
+  # TheHive object storage configuration
+  storage:
+    # Credentials to connect to the object storage
+    # They should match the credentials for MinIO subchart below (if enabled)
+    accessKey: "minio"
+    secretKey: "ChangeThisPasswordForMinIO"
+    # The name of an existing k8s secret containing the object storage secret key
+    k8sSecretName: ""
+    k8sSecretKey: "rootPassword"
+    # Bucket information
+    # Auto set to MinIO subchart service if enabled and this string is empty: "http://{{ .Release.Name }}-minio:9000"
+    endpoint: ""
+    bucket: "thehive"
+    region: "us-east-1"
+    usePathAccessStyle: true
+
+  # Add init containers to TheHive deployment (to wait for Cassandra and ElasticSearch to be reachable)
+  initContainers:
+    image:
+      registry: docker.io
+      repository: busybox
+      tag: "1.36.1-glibc"
+      pullPolicy: IfNotPresent
+
+    # Wait for Cassandra to be reachable on port 9042
+    checkCassandra:
+      enabled: true
+
+    # Wait for ElasticSearch "/_cluster/health" route on port 9200 to answer
+    checkElasticsearch:
+      enabled: true
+
+  # TheHive HTTP secret
+  httpSecret: ""
+  # The name of an existing k8s secret containing the HTTP secret used by TheHive
   k8sSecretName: ""
-  k8sSecretKey: "api-keys"
+  k8sSecretKey: "http-secret"
 
-# Custom application.conf file for TheHive (included on startup)
-extraConfig: ""
-#extraConfig: |
-#  # TheHive configuration file
-#  # See https://docs.strangebee.com/thehive/overview/ under the "Configuration" section
+  # Cortex configuration
+  # You can also add Cortex servers directly from TheHive UI https://docs.strangebee.com/thehive/administration/cortex/
+  cortex:
+    enabled: false
+    # Cortex protocol (expected values are "http" or "https")
+    protocol: "http"
+    # List of Cortex hostnames to configure
+    hostnames: []
+      #- "mycortex.example.com"
+    port: 9001
+    # Cortex API keys
+    # Each API key will be mapped to a single Cortex hostname (following the order in this YAML)
+    api_keys: []
+      #- "abcdefghijklmnopqrstuvwxyz012345"
+    # Alternatively, the name of an existing k8s secret containing all API keys for TheHive to connect to Cortex servers
+    # Expected format: "<key>,<key>,..."
+    k8sSecretName: ""
+    k8sSecretKey: "api-keys"
 
-# Extra entrypoint arguments
-extraCommand: []
+  # Custom application.conf file for TheHive (included on startup)
+  extraConfig: ""
+  #extraConfig: |
+  #  # TheHive configuration file
+  #  # See https://docs.strangebee.com/thehive/overview/ under the "Configuration" section
 
-# Extra environment variables
-extraEnv: []
-  #- name: "EXAMPLE"
-  #  value: "example"
-  #- name: "FROM_CM"
-  #  valueFrom:
-  #    configMapKeyRef:
-  #      name: "cm-name"
-  #      key: "key-name"
-  #- name: "FROM_SECRET"
-  #  valueFrom:
-  #    secretKeyRef:
-  #      name: "cm-name"
-  #      key: "key-name"
+  # Extra entrypoint arguments
+  extraCommand: []
 
-# Startup probe (set "failureThreshold" to a high value to prevent CrashLoops during schema migrations)
-startupProbe:
-  enabled: true
-  initialDelaySeconds: 0
-  periodSeconds: 5
-  timeoutSeconds: 1
-  failureThreshold: 36
+  # Extra environment variables
+  extraEnv: []
+    #- name: "EXAMPLE"
+    #  value: "example"
+    #- name: "FROM_CM"
+    #  valueFrom:
+    #    configMapKeyRef:
+    #      name: "cm-name"
+    #      key: "key-name"
+    #- name: "FROM_SECRET"
+    #  valueFrom:
+    #    secretKeyRef:
+    #      name: "cm-name"
+    #      key: "key-name"
 
-# Liveness probe
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 0
-  periodSeconds: 10
-  timeoutSeconds: 1
-  failureThreshold: 3
+  # Startup probe (set "failureThreshold" to a high value to prevent CrashLoops during schema migrations)
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 36
 
-# Readiness probe
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 0
-  periodSeconds: 10
-  timeoutSeconds: 1
-  successThreshold: 1
-  failureThreshold: 3
+  # Liveness probe
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
 
-serviceAccount:
-  # Create a ServiceAccount for TheHive
-  create: true
-  # The name of the service account to use (generated automatically if empty)
-  name: ""
-  # Whether to automatically mount the Service Account's token in pod
-  automount: true
-  # Annotations to add to the service account
-  annotations: {}
+  # Readiness probe
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
 
-podAnnotations: {}
-podLabels: {}
+  serviceAccount:
+    # Create a ServiceAccount for TheHive
+    create: true
+    # The name of the service account to use (generated automatically if empty)
+    name: ""
+    # Whether to automatically mount the Service Account's token in pod
+    automount: true
+    # Annotations to add to the service account
+    annotations: {}
 
-# https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-# Pod wide security context
-podSecurityContext: {}
-  #fsGroup: 2000
+  podAnnotations: {}
+  podLabels: {}
 
-# Container wide security context
-securityContext: {}
-  #allowPrivilegeEscalation: false
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Pod wide security context
+  podSecurityContext: {}
+    #fsGroup: 2000
 
-service:
-  type: ClusterIP
-  port: 9000
+  # Container wide security context
+  securityContext: {}
+    #allowPrivilegeEscalation: false
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    #kubernetes.io/ingress.class: nginx
-    #kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-    #- secretName: chart-example-tls
-    #  hosts:
-    #    - chart-example.local
+  service:
+    type: ClusterIP
+    port: 9000
 
-# Additional volumes for TheHive Deployment
-volumes: []
-  #- name: foo
-  #  secret:
-  #    secretName: mysecret
-  #    optional: false
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+      #kubernetes.io/ingress.class: nginx
+      #kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+      #- secretName: chart-example-tls
+      #  hosts:
+      #    - chart-example.local
 
-# Additional volumeMounts for TheHive Deployment
-volumeMounts: []
-  #- name: foo
-  #  mountPath: "/etc/foo"
-  #  readOnly: true
+  # Additional volumes for TheHive Deployment
+  volumes: []
+    #- name: foo
+    #  secret:
+    #    secretName: mysecret
+    #    optional: false
 
-nodeSelector: {}
+  # Additional volumeMounts for TheHive Deployment
+  volumeMounts: []
+    #- name: foo
+    #  mountPath: "/etc/foo"
+    #  readOnly: true
 
-tolerations: []
+  nodeSelector: {}
 
-affinity: {}
+  tolerations: []
+
+  affinity: {}
 
 ################################
 # Cassandra subchart variables #


### PR DESCRIPTION
Changes summary:
- (BREAKING CHANGE) Add `thehive` key as root for all TheHive related configs in `values.yaml`
- (BREAKING CHANGE) Rename `extraConfig` key to `applicationConf` to remove ambiguity when talking [about TheHive `application.conf` file](https://docs.strangebee.com/thehive/configuration/pekko/) to configure the application