### PR TITLE
Update TheHive to v5.4.9-1 and other softwares versions

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix regressions introduced in [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44) and [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45) [#47](https://github.com/StrangeBeeCorp/helm-charts/pull/47)
 - Add probe configs and update TheHive healthcheck route [#48](https://github.com/StrangeBeeCorp/helm-charts/pull/48)
 - (BREAKING CHANGE) Add "thehive" root key and rename application.conf variable [#49](https://github.com/StrangeBeeCorp/helm-charts/pull/49)
+- Update README and values.yaml comments [#50](https://github.com/StrangeBeeCorp/helm-charts/pull/50)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -4,10 +4,11 @@
 - Create dedicated templates for TheHive Role and RoleBinding manifests [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44)
 - (BREAKING CHANGE) Change initContainers config and values [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45)
 - Add parameters in TheHive values.yaml to configure Cortex servers [#46](https://github.com/StrangeBeeCorp/helm-charts/pull/46)
-- Fix regressions introduced in [#44](https://github.com/StrangeBeeCorp/helm-charts/pull/44) and [#45](https://github.com/StrangeBeeCorp/helm-charts/pull/45) [#47](https://github.com/StrangeBeeCorp/helm-charts/pull/47)
+- Fix regressions introduced in #44 and #45 [#47](https://github.com/StrangeBeeCorp/helm-charts/pull/47)
 - Add probe configs and update TheHive healthcheck route [#48](https://github.com/StrangeBeeCorp/helm-charts/pull/48)
 - (BREAKING CHANGE) Add "thehive" root key and rename application.conf variable [#49](https://github.com/StrangeBeeCorp/helm-charts/pull/49)
 - Update README and values.yaml comments [#50](https://github.com/StrangeBeeCorp/helm-charts/pull/50)
+- Update TheHive to v5.4.9-1 and other softwares versions [#51](https://github.com/StrangeBeeCorp/helm-charts/pull/51)
 
 
 ## 0.2.2

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 
 name: thehive
 version: 0.2.2
-appVersion: "5.4.8-1"
+appVersion: "5.4.9-1"
 kubeVersion: ">= 1.23.0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.4.8-1
+      image: strangebee/thehive:5.4.9-1
       whitelisted: true
     - name: busybox
       image: busybox:1.36.1-glibc

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: cassandra.enabled
   - name: elasticsearch
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 21.3.26
+    version: 21.4.9
     condition: elasticsearch.enabled
   - name: minio
     repository: https://charts.min.io

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -9,7 +9,7 @@ kubeVersion: ">= 1.23.0"
 dependencies:
   - name: cassandra
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 12.0.5
+    version: 12.2.2
     condition: cassandra.enabled
   - name: elasticsearch
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     condition: elasticsearch.enabled
   - name: minio
     repository: https://charts.min.io
-    version: 5.3.0
+    version: 5.4.0
     condition: minio.enabled
 
 type: application

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -45,7 +45,7 @@ annotations:
       image: strangebee/thehive:5.4.9-1
       whitelisted: true
     - name: busybox
-      image: busybox:1.36.1-glibc
+      image: busybox:1.37.0-glibc
       whitelisted: true
   artifacthub.io/license: AGPL-3.0
   artifacthub.io/links: |

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -1,6 +1,6 @@
 # TheHive Helm Chart
 
-[![Chart version 0.2.2](https://img.shields.io/badge/Chart_version-0.2.2-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.2.2) [![App version 5.4.8-1](https://img.shields.io/badge/App_version-5.4.8--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/)
+[![Chart version 0.2.2](https://img.shields.io/badge/Chart_version-0.2.2-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.2.2) [![App version 5.4.9-1](https://img.shields.io/badge/App_version-5.4.9--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/)
 
 The [official Helm Chart](https://github.com/StrangeBeeCorp/helm-charts) of [TheHive](https://strangebee.com/thehive/) for Kubernetes.
 

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -241,7 +241,7 @@ thehive:
 # Cassandra subchart variables #
 ################################
 
-# https://github.com/bitnami/charts/blob/cassandra/12.0.5/bitnami/cassandra/values.yaml
+# https://github.com/bitnami/charts/blob/cassandra/12.2.2/bitnami/cassandra/values.yaml
 cassandra:
   # Use Cassandra dependency Helm Chart
   enabled: true

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -95,7 +95,7 @@ thehive:
     image:
       registry: docker.io
       repository: busybox
-      tag: "1.36.1-glibc"
+      tag: "1.37.0-glibc"
       pullPolicy: IfNotPresent
 
     # Wait for Cassandra to be reachable on port 9042

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -384,11 +384,11 @@ minio:
 
   image:
     repository: quay.io/minio/minio
-    tag: RELEASE.2024-11-07T00-52-20Z
+    tag: RELEASE.2024-12-18T13-15-44Z
 
   mcImage:
     repository: quay.io/minio/mc
-    tag: RELEASE.2024-11-17T19-35-25Z
+    tag: RELEASE.2024-11-21T17-21-54Z
 
   rootUser: "minio"
   rootPassword: "ChangeThisPasswordForMinIO"

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -305,7 +305,7 @@ cassandra:
 # ElasticSearch subchart variables #
 ####################################
 
-# https://github.com/bitnami/charts/blob/elasticsearch/21.3.26/bitnami/elasticsearch/values.yaml
+# https://github.com/bitnami/charts/blob/elasticsearch/21.4.9/bitnami/elasticsearch/values.yaml
 elasticsearch:
   # Use ElasticSearch dependency Helm Chart
   enabled: true
@@ -313,7 +313,7 @@ elasticsearch:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch
-    tag: "8.16.1-debian-12-r1"
+    tag: "8.17.4-debian-12-r0"
 
   # Automatically filled by values under the "index" key defined above
   security:


### PR DESCRIPTION
Changes summary:
- Add missing #50 entry in `CHANGELOG.md`
- Update TheHive [from `5.4.8-1` to `5.4.9-1`](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/#549-march-25-2025)
- Update Cassandra dependency Helm Chart [from `v12.0.5` to `v12.2.2`](https://github.com/bitnami/charts/blob/main/bitnami/cassandra/CHANGELOG.md#1222-2025-03-12)
- Update ElasticSearch dependency Helm Chart [from `v21.3.26` to `v21.4.9`](https://github.com/bitnami/charts/blob/main/bitnami/elasticsearch/CHANGELOG.md#2149-2025-03-25)
- Update ElasticSearch container image from `v8.16.1-debian-12-r1` to `v8.17.4-debian-12-r0`
- Update MinIO dependency Helm Chart [from `v5.3.0` to `v5.4.0`](https://github.com/minio/minio/commit/43a74029685512ce9b1b76c053d48b43fc8d64fc)
- Use `minio/minio` image version `RELEASE.2024-12-18T13-15-44Z` to match the one used in MinIO Helm Chart `v5.4.0`
- Use `minio/mc` image version `RELEASE.2024-11-21T17-21-54Z` to match the one used in MinIO Helm Chart `v5.4.0`
- Update busybox image version from `v1.36.1-glibc` to `v1.37.0-glibc`