### PR TITLE
Add config to tweak TheHive Deployment strategy

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- Add config to tweak TheHive Deployment strategy [#53](https://github.com/StrangeBeeCorp/helm-charts/pull/53)
 
 
 ## 0.3.0

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "thehive.selectorLabels" . | nindent 6 }}
+  {{- with .Values.thehive.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.thehive.podAnnotations }}

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -19,6 +19,15 @@ thehive:
 
   replicaCount: 2
 
+  # TheHive Deployment strategy
+  strategy:
+    # Prefer "Recreate" since schema migrations can lead to errors on pods running older TheHive versions
+    type: Recreate
+    # Only used for "RollingUpdate" strategy type
+    #rollingUpdate:
+    #  maxSurge: 1
+    #  maxUnavailable: 1
+
   # TheHive nodes count
   clusterMinNodesCount: 1
 


### PR DESCRIPTION
Changes summary:
- Add configuration in `values.yaml` to tweak TheHive Deployment strategy
- Set TheHive default Deployment strategy type to `Recreate` since schema migrations can lead to errors on pods running older TheHive versions