### PR TITLE
Add missing selector labels in TheHive Pekko config

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
 - Add config to tweak TheHive Deployment strategy [#53](https://github.com/StrangeBeeCorp/helm-charts/pull/53)
+- Add missing selector labels in TheHive Pekko config [#54](https://github.com/StrangeBeeCorp/helm-charts/pull/54)
 
 
 ## 0.3.0

--- a/thehive-charts/thehive/templates/_helpers.tpl
+++ b/thehive-charts/thehive/templates/_helpers.tpl
@@ -39,6 +39,11 @@ app.kubernetes.io/name: {{ include "thehive.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{/* TheHive selector labels formatted for TheHive Pekko config */}}
+{{- define "thehive.selectorLabelsForPekko" -}}
+  {{- printf "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s" (include "thehive.name" .) .Release.Name | quote }}
+{{- end }}
+
 {{/* TheHive labels */}}
 {{- define "thehive.labels" -}}
 {{ include "thehive.commonLabels" . }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - "/opt/thehive/entrypoint"
             - "--kubernetes"
             - "--kubernetes-pod-label-selector"
-            - "app.kubernetes.io/name={{ include "thehive.name" . }}"
+            - {{ include "thehive.selectorLabelsForPekko" . }}
             {{ if not .Values.thehive.database.wait -}}- "--no-cql-wait"{{- end }}
             - "--index-backend"
             - "elasticsearch"


### PR DESCRIPTION
Changes summary:
- Define a new `thehive.selectorLabelsForPekko` template to format selector labels as expected by Pekko
- Use this new template as value for `--kubernetes-pod-label-selector` flag in TheHive Deployment