### PR TITLE
Move TheHive parameters from command flags to env vars in ConfigMap

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add config to tweak TheHive Deployment strategy [#53](https://github.com/StrangeBeeCorp/helm-charts/pull/53)
 - Add missing selector labels in TheHive Pekko config [#54](https://github.com/StrangeBeeCorp/helm-charts/pull/54)
+- Move TheHive parameters from command flags to env vars in ConfigMap [#55](https://github.com/StrangeBeeCorp/helm-charts/pull/55)
 
 
 ## 0.3.0

--- a/thehive-charts/thehive/templates/configmap-env.yaml
+++ b/thehive-charts/thehive/templates/configmap-env.yaml
@@ -5,17 +5,31 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:
+  TH_KUBERNETES: "1"
+  TH_KUBERNETES_POD_LABEL_SELECTOR: {{ include "thehive.selectorLabelsForPekko" . }}
+  TH_CLUSTER_MIN_NODES_COUNT: {{ .Values.thehive.clusterMinNodesCount | quote }}
   TH_CQL_USERNAME: {{ .Values.thehive.database.username | quote }}
   {{- if and (.Values.cassandra.enabled) (eq (len .Values.thehive.database.hostnames) 0) }}
   TH_CQL_HOSTNAMES: {{ printf "%s-cassandra" .Release.Name | trunc 63 | quote }}
   {{- else }}
   TH_CQL_HOSTNAMES: {{ join "," .Values.thehive.database.hostnames | quote }}
   {{- end }}
+  {{- if .Values.thehive.database.wait }}
+  TH_CQL_WAIT: "1"
+  {{- else }}
+  TH_CQL_WAIT: "0"
+  {{- end }}
+  TH_INDEX_BACKEND: "elasticsearch"
   TH_ELASTICSEARCH_USERNAME: {{ .Values.thehive.index.username | quote }}
   {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.thehive.index.hostnames) 0) }}
   TH_ELASTICSEARCH_HOSTNAMES: {{ printf "%s-elasticsearch" .Release.Name | trunc 63 | quote }}
   {{- else }}
   TH_ELASTICSEARCH_HOSTNAMES: {{ join "," .Values.thehive.index.hostnames | quote }}
+  {{- end }}
+  {{- if .Values.thehive.storage.usePathAccessStyle }}
+  TH_S3_USE_PATH_ACCESS_STYLE: "1"
+  {{- else }}
+  TH_S3_USE_PATH_ACCESS_STYLE: "0"
   {{- end }}
   TH_S3_ACCESS_KEY: {{ .Values.thehive.storage.accessKey | quote }}
   {{- if and (.Values.minio.enabled) (empty .Values.thehive.storage.endpoint) }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -66,15 +66,6 @@ spec:
           imagePullPolicy: {{ .Values.thehive.image.pullPolicy }}
           command:
             - "/opt/thehive/entrypoint"
-            - "--kubernetes"
-            - "--kubernetes-pod-label-selector"
-            - {{ include "thehive.selectorLabelsForPekko" . }}
-            {{ if not .Values.thehive.database.wait -}}- "--no-cql-wait"{{- end }}
-            - "--index-backend"
-            - "elasticsearch"
-            {{ if .Values.thehive.storage.usePathAccessStyle -}}- "--s3-use-path-access-style"{{- end }}
-            - "--cluster-min-nodes-count"
-            - "{{ .Values.thehive.clusterMinNodesCount }}"
           {{- with .Values.thehive.extraCommand }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Changes summary:
- Replace `--kubernetes` with `TH_KUBERNETES: "1"`
- Replace `--kubernetes-pod-label-selector` with `TH_KUBERNETES_POD_LABEL_SELECTOR`
- Replace `--cluster-min-nodes-count` with `TH_CLUSTER_MIN_NODES_COUNT`
- Replace `--no-cql-wait` with `TH_CQL_WAIT: "0"`
- Replace `--index-backend elasticsearch` with `TH_INDEX_BACKEND: "elasticsearch"`
- Replace `--s3-use-path-access-style` with `TH_S3_USE_PATH_ACCESS_STYLE: "1"`