### PR TITLE
Add "logback.xml" optional file in ConfigMap

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add config to tweak TheHive Deployment strategy [#53](https://github.com/StrangeBeeCorp/helm-charts/pull/53)
 - Add missing selector labels in TheHive Pekko config [#54](https://github.com/StrangeBeeCorp/helm-charts/pull/54)
 - Move TheHive parameters from command flags to env vars in ConfigMap [#55](https://github.com/StrangeBeeCorp/helm-charts/pull/55)
+- Add "logback.xml" optional file in ConfigMap [#56](https://github.com/StrangeBeeCorp/helm-charts/pull/56)
 
 
 ## 0.3.0

--- a/thehive-charts/thehive/templates/configmap-file.yaml
+++ b/thehive-charts/thehive/templates/configmap-file.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.thehive.applicationConf }}
+{{- if or (.Values.thehive.applicationConf) (.Values.thehive.logbackXml) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,5 +6,10 @@ metadata:
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:
+  {{- if .Values.thehive.applicationConf }}
   application.conf: {{- .Values.thehive.applicationConf | toYaml | indent 1 }}
+  {{- end }}
+  {{- if .Values.thehive.logbackXml }}
+  logback.xml: {{- .Values.thehive.logbackXml | toYaml | indent 1 }}
+  {{- end }}
 {{- end }}

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.thehive.resources | nindent 12 }}
-          {{- if or .Values.thehive.volumeMounts .Values.thehive.applicationConf }}
+          {{- if or (.Values.thehive.volumeMounts) (.Values.thehive.applicationConf) (.Values.thehive.logbackXml) }}
           volumeMounts:
           {{- if .Values.thehive.applicationConf }}
             - name: config
@@ -165,13 +165,19 @@ spec:
               subPath: application.conf
               readOnly: true
           {{- end -}}
+          {{- if .Values.thehive.logbackXml }}
+            - name: config
+              mountPath: /etc/thehive/logback.xml
+              subPath: logback.xml
+              readOnly: true
+          {{- end -}}
           {{- with .Values.thehive.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
-      {{- if or .Values.thehive.volumes .Values.thehive.applicationConf }}
+      {{- if or (.Values.thehive.volumes) (.Values.thehive.applicationConf) (.Values.thehive.logbackXml) }}
       volumes:
-      {{- if .Values.thehive.applicationConf }}
+      {{- if or (.Values.thehive.applicationConf) (.Values.thehive.logbackXml) }}
         - name: config
           configMap:
             name: {{ include "thehive.fullname" . }}-config

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -146,6 +146,12 @@ thehive:
   #  # TheHive configuration file
   #  # See https://docs.strangebee.com/thehive/overview/ under the "Configuration" section
 
+  # Custom logback.xml file for TheHive
+  logbackXml: ""
+  #logbackXml: |
+  #  <!-- TheHive logs configuration file -->
+  #  <!-- See https://docs.strangebee.com/thehive/configuration/logs/ -->
+
   # Extra entrypoint arguments
   extraCommand: []
 


### PR DESCRIPTION
Changes summary:
- Add an optional `logback.xml` file to the ConfigMap
- Add a `logbackXml` key mapped to the ConfigMap to customize TheHive logging