### PR TITLE
Update TheHive to v5.5.0-1 and other softwares versions

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add missing selector labels in TheHive Pekko config [#54](https://github.com/StrangeBeeCorp/helm-charts/pull/54)
 - Move TheHive parameters from command flags to env vars in ConfigMap [#55](https://github.com/StrangeBeeCorp/helm-charts/pull/55)
 - Add "logback.xml" optional file in ConfigMap [#56](https://github.com/StrangeBeeCorp/helm-charts/pull/56)
+- Update TheHive to v5.5.0-1 and other softwares versions [#57](https://github.com/StrangeBeeCorp/helm-charts/pull/57)
 
 
 ## 0.3.0

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -9,7 +9,7 @@ kubeVersion: ">= 1.23.0"
 dependencies:
   - name: cassandra
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 12.2.2
+    version: 12.2.3
     condition: cassandra.enabled
   - name: elasticsearch
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 
 name: thehive
 version: 0.3.0
-appVersion: "5.4.9-1"
+appVersion: "5.5.0-1"
 kubeVersion: ">= 1.23.0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.4.9-1
+      image: strangebee/thehive:5.5.0-1
       whitelisted: true
     - name: busybox
       image: busybox:1.37.0-glibc

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -1,6 +1,6 @@
 # TheHive Helm Chart
 
-[![Chart version 0.3.0](https://img.shields.io/badge/Chart_version-0.3.0-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.3.0) [![App version 5.4.9-1](https://img.shields.io/badge/App_version-5.4.9--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.4/)
+[![Chart version 0.3.0](https://img.shields.io/badge/Chart_version-0.3.0-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.3.0) [![App version 5.5.0-1](https://img.shields.io/badge/App_version-5.5.0--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
 
 The [official Helm Chart](https://github.com/StrangeBeeCorp/helm-charts) of [TheHive](https://strangebee.com/thehive/) for Kubernetes.
 

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -328,7 +328,7 @@ elasticsearch:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch
-    tag: "8.17.4-debian-12-r0"
+    tag: "8.17.4-debian-12-r4"
 
   # Automatically filled by values under the "index" key defined above
   security:


### PR DESCRIPTION
Changes summary:
- Update TheHive [from `5.4.9-1` to `5.5.0-1`](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/#550-april-22-2025)
- Update Cassandra dependency Helm Chart [from `v12.2.2` to `v12.2.3`](https://github.com/bitnami/charts/blob/main/bitnami/cassandra/CHANGELOG.md#1223-2025-04-04)
- Update ElasticSearch container image from `v8.17.4-debian-12-r0` to `v8.17.4-debian-12-r4`