### PR TITLE
Update TheHive to v5.5.1-1

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- Update TheHive to v5.5.1-1 [#59](https://github.com/StrangeBeeCorp/helm-charts/pull/59)
 
 
 ## 0.3.1

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 
 name: thehive
 version: 0.3.1
-appVersion: "5.5.0-1"
+appVersion: "5.5.1-1"
 kubeVersion: ">= 1.23.0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.5.0-1
+      image: strangebee/thehive:5.5.1-1
       whitelisted: true
     - name: busybox
       image: busybox:1.37.0-glibc

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -1,6 +1,6 @@
 # TheHive Helm Chart
 
-[![Chart version 0.3.1](https://img.shields.io/badge/Chart_version-0.3.1-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.3.1) [![App version 5.5.0-1](https://img.shields.io/badge/App_version-5.5.0--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
+[![Chart version 0.3.1](https://img.shields.io/badge/Chart_version-0.3.1-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.3.1) [![App version 5.5.1-1](https://img.shields.io/badge/App_version-5.5.1--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
 
 The [official Helm Chart](https://github.com/StrangeBeeCorp/helm-charts) of [TheHive](https://strangebee.com/thehive/) for Kubernetes.
 


### PR DESCRIPTION
Changes summary:
- Update TheHive [from `5.5.0-1` to `5.5.1-1`](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/#551-april-30-2025)