### PR TITLE
Add logback.xml optional file to Cortex Deployment

### DIFF
--- a/cortex-charts/cortex/templates/configmap-file.yaml
+++ b/cortex-charts/cortex/templates/configmap-file.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortex.configFile -}}
+{{- if or (.Values.cortex.configFile) (.Values.cortex.logbackXml) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,5 +6,10 @@ metadata:
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 data:
+  {{- if .Values.cortex.configFile }}
   application.conf: {{- .Values.cortex.configFile | toYaml | indent 1 }}
+  {{- end }}
+  {{- if .Values.cortex.logbackXml }}
+  logback.xml: {{- .Values.cortex.logbackXml | toYaml | indent 1 }}
+  {{- end }}
 {{- end -}}

--- a/cortex-charts/cortex/templates/deployment.yaml
+++ b/cortex-charts/cortex/templates/deployment.yaml
@@ -110,6 +110,12 @@ spec:
               subPath: application.conf
               readOnly: true
           {{- end }}
+          {{- if .Values.cortex.logbackXml }}
+            - name: config
+              mountPath: /etc/cortex/logback.xml
+              subPath: logback.xml
+              readOnly: true
+          {{- end -}}
           {{- with .Values.cortex.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -117,7 +123,7 @@ spec:
         - name: cortex-job-shared-pvc
           persistentVolumeClaim:
             claimName: {{ include "cortex.persistentVolumeClaimName" . }}
-      {{- if .Values.cortex.configFile }}
+      {{- if or (.Values.cortex.configFile) (.Values.cortex.logbackXml) }}
         - name: config
           configMap:
             name: {{ include "cortex.fullname" . }}-config

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -127,6 +127,12 @@ cortex:
       }
     }
 
+  # Custom logback.xml file for Cortex
+  logbackXml: ""
+  #logbackXml: |
+  #  <!-- Cortex logs configuration file -->
+  #  <!-- See https://docs.strangebee.com/cortex/installation-and-configuration/#configuration-guides -->
+
   startupProbe:
     enabled: true
 


### PR DESCRIPTION
Changes summary:
- Add `logbackXml` key in `values.yaml` to customize Cortex logging
- Load custom `logback.xml` file in Cortex Deployment file if set by the Chart user