### PR TITLE
Move Cortex container command flags to env vars in ConfigMap

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `deletecollection` permission on jobs to Cortex role [#67](https://github.com/StrangeBeeCorp/helm-charts/pull/67)
 - Add correct link to Cortex `v3.2.0` release page in README [#70](https://github.com/StrangeBeeCorp/helm-charts/pull/70)
 - Add `logback.xml` optional file to Cortex Deployment [#71](https://github.com/StrangeBeeCorp/helm-charts/pull/71)
+- Move Cortex container command flags to env vars in ConfigMap [#72](https://github.com/StrangeBeeCorp/helm-charts/pull/72)
 
 
 ## 0.1.0

--- a/cortex-charts/cortex/templates/configmap-env.yaml
+++ b/cortex-charts/cortex/templates/configmap-env.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 data:
-  kubernetes_job_pvc: {{ include "cortex.persistentVolumeClaimName" . | quote }}
-  job_directory: {{ .Values.cortex.jobDirectory | quote }}
   {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.cortex.index.hostnames) 0) }}
   es_hostname: {{ printf "%s-elasticsearch" .Release.Name | trunc 63 | quote }}
   {{- else }}
   es_hostname: {{ join "," .Values.cortex.index.hostnames | quote }}
   {{- end }}
+  job_directory: {{ .Values.cortex.jobDirectory | quote }}
+  kubernetes_job_pvc: {{ include "cortex.persistentVolumeClaimName" . | quote }}

--- a/cortex-charts/cortex/templates/configmap-env.yaml
+++ b/cortex-charts/cortex/templates/configmap-env.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cortex.fullname" . }}-env
+  labels:
+    {{- include "cortex.labels" . | nindent 4 }}
+data:
+  kubernetes_job_pvc: {{ include "cortex.persistentVolumeClaimName" . | quote }}
+  job_directory: {{ .Values.cortex.jobDirectory | quote }}
+  {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.cortex.index.hostnames) 0) }}
+  es_hostname: {{ printf "%s-elasticsearch" .Release.Name | trunc 63 | quote }}
+  {{- else }}
+  es_hostname: {{ join "," .Values.cortex.index.hostnames | quote }}
+  {{- end }}

--- a/cortex-charts/cortex/templates/deployment.yaml
+++ b/cortex-charts/cortex/templates/deployment.yaml
@@ -45,16 +45,6 @@ spec:
           imagePullPolicy: {{ .Values.cortex.image.pullPolicy }}
           command:
             - /opt/cortex/entrypoint
-            - --es-hostname
-            {{- if and (.Values.elasticsearch.enabled) (eq (len .Values.cortex.index.hostnames) 0) }}
-            - {{ printf "%s-elasticsearch" .Release.Name | trunc 63 | quote }}
-            {{- else }}
-            - {{ join "," .Values.cortex.index.hostnames | quote }}
-            {{- end}}
-            - --job-directory
-            - {{ .Values.cortex.jobDirectory }}
-            - --kubernetes-job-pvc
-            - {{ include "cortex.persistentVolumeClaimName" . }}
           {{- with .Values.cortex.extraCommand }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -72,6 +62,8 @@ spec:
                   key: {{ .Values.cortex.k8sSecretKey }}
             {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ include "cortex.fullname" . }}-env
             {{- if not .Values.cortex.k8sSecretName }}
             - secretRef:
                 name: {{ include "cortex.fullname" . }}-secrets


### PR DESCRIPTION
Changes summary:
- Create a dedicated ConfigMap to regroup env variables for Cortex
- Move Cortex container command flags to the new ConfigMap as env vars