### PR TITLE
(BREAKING CHANGE) Rework labels and annotations in TheHive Helm Chart

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- (BREAKING CHANGE) Rework labels and annotations in TheHive Helm Chart [#77](https://github.com/StrangeBeeCorp/helm-charts/pull/77)
 
 
 ## 0.3.6

--- a/thehive-charts/thehive/templates/_helpers.tpl
+++ b/thehive-charts/thehive/templates/_helpers.tpl
@@ -31,6 +31,9 @@ app.kubernetes.io/version: {{ .Values.thehive.image.tag | default .Chart.AppVers
 app.kubernetes.io/part-of: {{ include "thehive.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "thehive.chart" . }}
+{{- with .Values.thehive.labels }}
+{{ toYaml . }}
+{{- end -}}
 {{- end -}}
 
 {{/* TheHive selector labels */}}

--- a/thehive-charts/thehive/templates/_helpers.tpl
+++ b/thehive-charts/thehive/templates/_helpers.tpl
@@ -1,58 +1,57 @@
 {{/* Expand the name of the chart */}}
 {{- define "thehive.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
-If release name contains chart name it will be used as a full name
 */}}
 {{- define "thehive.fullname" -}}
-{{- if .Values.fullnameOverride }}
-  {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-  {{- $name := default .Chart.Name .Values.nameOverride }}
-  {{- if contains $name .Release.Name }}
-    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-  {{- else }}
-    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-  {{- end }}
-{{- end }}
-{{- end }}
+{{- if .Values.fullnameOverride -}}
+  {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+  {{- $name := default .Chart.Name .Values.nameOverride -}}
+  {{- if contains $name .Release.Name -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{/* Create chart name and version as used by the chart label */}}
 {{- define "thehive.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
-{{/* Common labels */}}
-{{- define "thehive.commonLabels" -}}
-app.kubernetes.io/part-of: "TheHive"
+{{/* TheHive metaLabels */}}
+{{- define "thehive.metaLabels" -}}
+app.kubernetes.io/version: {{ .Values.thehive.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/part-of: {{ include "thehive.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-{{- end }}
+helm.sh/chart: {{ include "thehive.chart" . }}
+{{- end -}}
 
 {{/* TheHive selector labels */}}
-{{- define "thehive.selectorLabels" -}}
+{{- define "thehive.matchLabels" -}}
 app.kubernetes.io/name: {{ include "thehive.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+app.kubernetes.io/component: "server"
+{{- end -}}
 
-{{/* TheHive selector labels formatted for TheHive Pekko config */}}
+{{/* TheHive selector labels formatted for Pekko config */}}
 {{- define "thehive.selectorLabelsForPekko" -}}
   {{- printf "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s" (include "thehive.name" .) .Release.Name | quote }}
 {{- end }}
 
-{{/* TheHive labels */}}
+{{/* TheHive resources labels */}}
 {{- define "thehive.labels" -}}
-{{ include "thehive.commonLabels" . }}
-{{ include "thehive.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.thehive.image.tag | default .Chart.AppVersion | quote }}
-app.kubernetes.io/component: "frontend"
-{{- end }}
+{{ include "thehive.metaLabels" . }}
+{{ include "thehive.matchLabels" . }}
+{{- end -}}
 
-{{/* TheHive service account name */}}
+{{/* TheHive ServiceAccount name */}}
 {{- define "thehive.serviceAccountName" -}}
 {{- default (include "thehive.fullname" .) .Values.thehive.serviceAccount.name }}
-{{- end }}
+{{- end -}}

--- a/thehive-charts/thehive/templates/configmap-env.yaml
+++ b/thehive-charts/thehive/templates/configmap-env.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thehive.fullname" . }}-env
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:

--- a/thehive-charts/thehive/templates/configmap-file.yaml
+++ b/thehive-charts/thehive/templates/configmap-file.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "thehive.fullname" . }}-config
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 data:

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "thehive.fullname" . }}
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 spec:

--- a/thehive-charts/thehive/templates/deployment.yaml
+++ b/thehive-charts/thehive/templates/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "thehive.selectorLabels" . | nindent 6 }}
+      {{- include "thehive.matchLabels" . | nindent 6 }}
   {{- with .Values.thehive.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/thehive-charts/thehive/templates/hpa.yaml
+++ b/thehive-charts/thehive/templates/hpa.yaml
@@ -3,6 +3,10 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "thehive.fullname" . }}
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 spec:

--- a/thehive-charts/thehive/templates/pdb.yaml
+++ b/thehive-charts/thehive/templates/pdb.yaml
@@ -2,6 +2,10 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "thehive.fullname" . }}
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 spec:

--- a/thehive-charts/thehive/templates/role.yaml
+++ b/thehive-charts/thehive/templates/role.yaml
@@ -3,6 +3,10 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "thehive.serviceAccountName" . }}-pod-reader
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 rules:

--- a/thehive-charts/thehive/templates/rolebinding.yaml
+++ b/thehive-charts/thehive/templates/rolebinding.yaml
@@ -3,6 +3,10 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "thehive.serviceAccountName" . }}-pod-reader-binding
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 subjects:

--- a/thehive-charts/thehive/templates/secrets.yaml
+++ b/thehive-charts/thehive/templates/secrets.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "thehive.fullname" . }}-secrets
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 type: Opaque

--- a/thehive-charts/thehive/templates/service.yaml
+++ b/thehive-charts/thehive/templates/service.yaml
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "thehive.selectorLabels" . | nindent 4 }}
+    {{- include "thehive.matchLabels" . | nindent 4 }}

--- a/thehive-charts/thehive/templates/service.yaml
+++ b/thehive-charts/thehive/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "thehive.fullname" . }}
+  {{- with .Values.thehive.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "thehive.labels" . | nindent 4 }}
 spec:

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -9,6 +9,9 @@ imagePullSecrets: []
 #  - name: "image-pull-secret"
 
 thehive:
+  # Additional labels to attach to TheHive resources
+  labels: {}
+
   # TheHive container image
   image:
     registry: docker.io

--- a/thehive-charts/thehive/values.yaml
+++ b/thehive-charts/thehive/values.yaml
@@ -9,8 +9,14 @@ imagePullSecrets: []
 #  - name: "image-pull-secret"
 
 thehive:
-  # Additional labels to attach to TheHive resources
+  # Additional labels and annotations to attach to TheHive resources
+  # (dedicated keys exist for Ingress and ServiceAccount annotations)
   labels: {}
+  annotations: {}
+
+  # Additional labels and annotations to attach to TheHive pods
+  podLabels: {}
+  podAnnotations: {}
 
   # TheHive container image
   image:
@@ -204,9 +210,6 @@ thehive:
     annotations: {}
     # Whether to automatically mount Kubernetes API credentials
     automount: true
-
-  podAnnotations: {}
-  podLabels: {}
 
   # Pod wide security context https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   podSecurityContext: {}


### PR DESCRIPTION
Changes summary:
- Rename `selectorLabels` to `matchLabels` in `_helpers.tpl`
- (BREAKING CHANGE) Rename `thehive.additionalLabels` to `thehive.labels` in `values.yaml`
- Add `thehive.annotations` key in `values.yaml` and use it in most TheHive manifests (Ingress and ServiceAccount excluded since they already have dedicated keys)