### PR TITLE
Include -0 for the min kubernetes version to allow EKS versions

### DIFF
--- a/cortex-charts/cortex/Chart.yaml
+++ b/cortex-charts/cortex/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: cortex
 version: 0.2.0
 appVersion: "3.2.1-1"
-kubeVersion: ">= 1.23.0"
+kubeVersion: ">= 1.23.0-0"
 
 dependencies:
   - name: elasticsearch


### PR DESCRIPTION
The error stems from how Helm interprets AWS distro versions: it sees the "-eks" postfix as a pre-release tag, causing version constraint failures. As AWS isn't planning to alter its existing naming convention, we should implement the workaround directly in the Chart.yaml file. You can find more details in this GitHub [issue](https://github.com/helm/helm/issues/10375).