### PR TITLE
(BREAKING CHANGE) Target Bitnami Legacy repository for images used in dependency charts

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next release
 
-- Tweak kubeVersion constraints to accept EKS specific versions [#80](https://github.com/StrangeBeeCorp/helm-charts/pull/80) [#81](https://github.com/StrangeBeeCorp/helm-charts/pull/81)
+- Tweak kubeVersion constraints to accept EKS specific versions [#80](https://github.com/StrangeBeeCorp/helm-charts/pull/80) [#81](https://github.com/StrangeBeeCorp/helm-charts/pull/81) by @julienbaladier
+- (BREAKING CHANGE) Target [Bitnami Legacy repository](https://github.com/bitnami/charts/issues/35164) for images used in dependency charts [#82](https://github.com/StrangeBeeCorp/helm-charts/pull/82)
 
 
 ## 0.2.0

--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -3,7 +3,8 @@
 - (BREAKING CHANGE) Rework labels and annotations in TheHive Helm Chart [#77](https://github.com/StrangeBeeCorp/helm-charts/pull/77)
 - (BREAKING CHANGE) Rework TheHive Helm Chart values and resources [#78](https://github.com/StrangeBeeCorp/helm-charts/pull/78)
 - Add monitoring configuration [#79](https://github.com/StrangeBeeCorp/helm-charts/pull/79)
-- Tweak kubeVersion constraints to accept EKS specific versions [#80](https://github.com/StrangeBeeCorp/helm-charts/pull/80) [#81](https://github.com/StrangeBeeCorp/helm-charts/pull/81)
+- Tweak kubeVersion constraints to accept EKS specific versions [#80](https://github.com/StrangeBeeCorp/helm-charts/pull/80) [#81](https://github.com/StrangeBeeCorp/helm-charts/pull/81) by @julienbaladier
+- (BREAKING CHANGE) Target [Bitnami Legacy repository](https://github.com/bitnami/charts/issues/35164) for images used in dependency charts [#82](https://github.com/StrangeBeeCorp/helm-charts/pull/82)
 
 
 ## 0.3.6


### PR DESCRIPTION
Relates to [Bitnami images and charts recent changes](https://github.com/bitnami/charts/issues/35164)

Changes summary:
- Use [bitnamilegacy](https://hub.docker.com/u/bitnamilegacy) DockerHub repository to replace [bitnami](https://hub.docker.com/u/bitnami) for specific images