### PR TITLE
Add missing condition in Ingress template on TLS block

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Tweak kubeVersion constraints to accept EKS specific versions [#80](https://github.com/StrangeBeeCorp/helm-charts/pull/80) [#81](https://github.com/StrangeBeeCorp/helm-charts/pull/81) by @julienbaladier
 - (BREAKING CHANGE) Target [Bitnami Legacy repository](https://github.com/bitnami/charts/issues/35164) for images used in dependency charts [#82](https://github.com/StrangeBeeCorp/helm-charts/pull/82)
+- Add missing condition in Ingress template on TLS block [#85](https://github.com/StrangeBeeCorp/helm-charts/pull/85)
 
 
 ## 0.2.0

--- a/cortex-charts/cortex/templates/ingress.yaml
+++ b/cortex-charts/cortex/templates/ingress.yaml
@@ -30,6 +30,7 @@ spec:
                   number: {{ .Values.cortex.service.port }}
           {{- end }}
     {{- end }}
+  {{- if .Values.cortex.ingress.tls }}
   tls:
     {{- range .Values.cortex.ingress.tls }}
     - hosts:
@@ -38,4 +39,5 @@ spec:
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Changes summary:
- Add missing test to create `tls` block in the Ingress template only if the `tls` value exists