### PR TITLE
Improve labels and annotations management

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Tweak kubeVersion constraints to accept EKS specific versions [#80](https://github.com/StrangeBeeCorp/helm-charts/pull/80) [#81](https://github.com/StrangeBeeCorp/helm-charts/pull/81) by @julienbaladier
 - (BREAKING CHANGE) Target [Bitnami Legacy repository](https://github.com/bitnami/charts/issues/35164) for images used in dependency charts [#82](https://github.com/StrangeBeeCorp/helm-charts/pull/82)
 - Add missing condition in Ingress template on TLS block [#85](https://github.com/StrangeBeeCorp/helm-charts/pull/85)
+- (BREAKING CHANGE) Improve annotations and labels management [#86](https://github.com/StrangeBeeCorp/helm-charts/pull/86)
 
 
 ## 0.2.0

--- a/cortex-charts/cortex/templates/_helpers.tpl
+++ b/cortex-charts/cortex/templates/_helpers.tpl
@@ -31,7 +31,7 @@ app.kubernetes.io/version: {{ .Values.cortex.image.tag | default .Chart.AppVersi
 app.kubernetes.io/part-of: {{ include "cortex.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "cortex.chart" . }}
-{{- with .Values.cortex.additionalLabels }}
+{{- with .Values.cortex.labels }}
 {{ toYaml . }}
 {{- end -}}
 {{- end -}}

--- a/cortex-charts/cortex/templates/configmap-env.yaml
+++ b/cortex-charts/cortex/templates/configmap-env.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "cortex.fullname" . }}-env
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 data:

--- a/cortex-charts/cortex/templates/configmap-file.yaml
+++ b/cortex-charts/cortex/templates/configmap-file.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "cortex.fullname" . }}-config
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 data:

--- a/cortex-charts/cortex/templates/deployment.yaml
+++ b/cortex-charts/cortex/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cortex.fullname" . }}
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 spec:
@@ -15,8 +19,15 @@ spec:
   {{- end }}
   template:
     metadata:
+      {{- with .Values.cortex.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "cortex.labels" . | nindent 8 }}
+        {{- with .Values.cortex.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/cortex-charts/cortex/templates/pvc.yaml
+++ b/cortex-charts/cortex/templates/pvc.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "cortex.persistentVolumeClaimName" . }}
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "cortex.labels" . | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/cortex-charts/cortex/templates/role.yaml
+++ b/cortex-charts/cortex/templates/role.yaml
@@ -3,6 +3,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "cortex.serviceAccountName" . }}-job-runner
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 rules:

--- a/cortex-charts/cortex/templates/rolebinding.yaml
+++ b/cortex-charts/cortex/templates/rolebinding.yaml
@@ -3,6 +3,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "cortex.serviceAccountName" . }}-job-runner-binding
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 roleRef:

--- a/cortex-charts/cortex/templates/secrets.yaml
+++ b/cortex-charts/cortex/templates/secrets.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "cortex.fullname" . }}-secrets
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 type: Opaque

--- a/cortex-charts/cortex/templates/service.yaml
+++ b/cortex-charts/cortex/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cortex.fullname" . }}
+  {{- with .Values.cortex.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cortex.labels" . | nindent 4 }}
 spec:

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -9,12 +9,12 @@ imagePullSecrets: []
 #  - name: "image-pull-secret"
 
 cortex:
-  # Additional labels and annotations to attach to TheHive resources
+  # Additional labels and annotations to attach to Cortex resources
   # (dedicated keys exist for Ingress and ServiceAccount annotations)
   labels: {}
   annotations: {}
 
-  # Additional labels and annotations to attach to TheHive pods
+  # Additional labels and annotations to attach to Cortex pods
   podLabels: {}
   podAnnotations: {}
 

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -9,8 +9,14 @@ imagePullSecrets: []
 #  - name: "image-pull-secret"
 
 cortex:
-  # Additional labels to attach to Cortex resources
-  additionalLabels: {}
+  # Additional labels and annotations to attach to TheHive resources
+  # (dedicated keys exist for Ingress and ServiceAccount annotations)
+  labels: {}
+  annotations: {}
+
+  # Additional labels and annotations to attach to TheHive pods
+  podLabels: {}
+  podAnnotations: {}
 
   replicas: 2
 


### PR DESCRIPTION
Changes summary:
- (BREAKING CHANGE) Rename `cortex.additionalLabels` to `cortex.labels` in `values.yaml`
- Add `cortex.annotations` key in `values.yaml` and use it in most Cortex manifests (Ingress and ServiceAccount excluded since they already have dedicated keys)
- Add `cortex.podAnnotations` and `cortex.podLabels` keys in `values.yaml`
- Add missing labels in PVC template