### PR TITLE
Use new download links for analyzers and responders configuration

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add missing condition in Ingress template on TLS block [#85](https://github.com/StrangeBeeCorp/helm-charts/pull/85)
 - (BREAKING CHANGE) Improve annotations and labels management [#86](https://github.com/StrangeBeeCorp/helm-charts/pull/86)
 - Improve configuration options for Deployment probes [#87](https://github.com/StrangeBeeCorp/helm-charts/pull/87)
+- Use new download links for analyzers and responders configuration [#88](https://github.com/StrangeBeeCorp/helm-charts/pull/88)
 
 
 ## 0.2.0

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -109,7 +109,7 @@ cortex:
     # See https://docs.strangebee.com/cortex/installation-and-configuration/#configuration-guides
     analyzer {
       urls: [
-        "https://download.thehive-project.org/analyzers.json",
+        "https://catalogs.download.strangebee.com/latest/json/analyzers.json",
       ]
 
       # Customize analyzers parallelism here
@@ -123,7 +123,7 @@ cortex:
       # Customize responders parallelism here
     responder {
       urls: [
-        "https://download.thehive-project.org/responders.json",
+        "https://catalogs.download.strangebee.com/latest/json/responders.json",
       ]
 
       fork-join-executor {


### PR DESCRIPTION
Changes summary:
- Replace `download.thehive-project.org` with the new `catalogs.download.strangebee.com` to download the JSONs for analyzers and responders