### PR TITLE
Update bitnami/elasticsearch dependency chart

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -6,6 +6,7 @@
 - (BREAKING CHANGE) Improve annotations and labels management [#86](https://github.com/StrangeBeeCorp/helm-charts/pull/86)
 - Improve configuration options for Deployment probes [#87](https://github.com/StrangeBeeCorp/helm-charts/pull/87)
 - Use new download links for analyzers and responders configuration [#88](https://github.com/StrangeBeeCorp/helm-charts/pull/88)
+- Update bitnami/elasticsearch dependency chart [#89](https://github.com/StrangeBeeCorp/helm-charts/pull/89)
 
 
 ## 0.2.0

--- a/cortex-charts/cortex/Chart.yaml
+++ b/cortex-charts/cortex/Chart.yaml
@@ -9,7 +9,7 @@ kubeVersion: ">= 1.23.0-0"
 dependencies:
   - name: elasticsearch
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 21.4.9
+    version: 22.1.0
     condition: elasticsearch.enabled
 
 type: application

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -234,10 +234,15 @@ cortex:
 # ElasticSearch subchart variables #
 ####################################
 
-# https://github.com/bitnami/charts/blob/elasticsearch/21.4.7/bitnami/elasticsearch/values.yaml
+# https://github.com/bitnami/charts/blob/elasticsearch/22.1.0/bitnami/elasticsearch/values.yaml
 elasticsearch:
   # Use ElasticSearch dependency Helm Chart
   enabled: true
+
+  # Skip image verification to allow bitnamilegacy repository images
+  global:
+    security:
+      allowInsecureImages: true
 
   # Cortex only supports ElasticSearch v7 at the time of writing
   image:


### PR DESCRIPTION
Changes summary:
- Update bitnami/elasticsearch dependency chart [from `21.4.9` to `22.1.0`](https://github.com/bitnami/charts/blob/main/bitnami/elasticsearch/CHANGELOG.md#2210-2025-08-01)
- Explicitly allow bitnamilegacy images in dependency chart config