### PR TITLE
fix(cortex helm): nil pointer when rendering ingress

### DIFF
--- a/cortex-charts/cortex/templates/ingress.yaml
+++ b/cortex-charts/cortex/templates/ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.cortex.ingress.enabled -}}
+{{- $fullName := include "cortex.fullname" . -}}
+{{- $servicePort := .Values.cortex.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -25,19 +27,13 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "cortex.fullname" . }}
+                name: {{ $fullName }}
                 port:
-                  number: {{ .Values.cortex.service.port }}
+                  number: {{ $servicePort }}
           {{- end }}
     {{- end }}
-  {{- if .Values.cortex.ingress.tls }}
+  {{- with .Values.cortex.ingress.tls }}
   tls:
-    {{- range .Values.cortex.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Resolves a 'nil pointer' error that occurs when rendering the Ingress template: `--set ingress.enabled=true`

```
Error: template: cortex/templates/ingress.yaml:28:25: executing "cortex/templates/ingress.yaml" at <include "cortex.fullname" .>: error calling include: template: cortex/templates/_helpers.tpl:11:14: executing "cortex.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```

The error was caused by calling the `cortex.fullname` helper from within a `range` loop, where the `.` context was incorrect.

This change also make the `secretName` property optional as some ingress controllers can use one by default.
