### PR TITLE
fix (thehive): ingress.yaml template had an incorrect context usage on service name and port

### DIFF
--- a/thehive-charts/thehive/templates/ingress.yaml
+++ b/thehive-charts/thehive/templates/ingress.yaml
@@ -25,9 +25,9 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "thehive.fullname" . }}
+                name: {{ include "thehive.fullname" $ }}
                 port:
-                  number: {{ .Values.thehive.service.port }}
+                  number: {{ $.Values.thehive.service.port }}
           {{- end }}
     {{- end }}
   {{- if .Values.thehive.ingress.tls }}


### PR DESCRIPTION
same as @julienbaladier, I got the same error on the thehive charts when  `--set ingress.enabled=true`

it says:
`Error: template: thehive/templates/ingress.yaml:28:25: executing "thehive/templates/ingress.yaml" at <include "thehive.fullname" .>: error calling include: template: thehive/templates/_helpers.tpl:11:14: executing "thehive.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride Use --debug flag to render out invalid YAML`

The problem appears to be caused by the nested range loops (around line 21) changing the template context to the current path object. This causes . to refer to the inner loop item instead of the root context, which breaks calls like {{ include "thehive.fullname" . }} and {{ .Values.thehive.service.port }}.

Workaround/Fix:
1. I updated the Ingress template so that these calls use `$` (the root context) instead of `.`, ensuring that references to helpers and .Values always point to the correct scope.
