### PR TITLE
Update TheHive to v5.5.10-1

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Nothing yet
+- Update TheHive to v5.5.10-1 [#100](https://github.com/StrangeBeeCorp/helm-charts/pull/100)
 
 
 ## 0.4.3

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 
 name: thehive
 version: 0.4.3
-appVersion: "5.5.9-1"
+appVersion: "5.5.10-1"
 kubeVersion: ">= 1.23.0-0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.5.9-1
+      image: strangebee/thehive:5.5.10-1
       whitelisted: true
     - name: busybox
       image: busybox:1.37.0-glibc

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -1,5 +1,5 @@
 # TheHive Helm Chart
 
-[![Chart version 0.4.3](https://img.shields.io/badge/Chart_version-0.4.3-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.4.3) [![App version 5.5.9-1](https://img.shields.io/badge/App_version-5.5.9--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
+[![Chart version 0.4.3](https://img.shields.io/badge/Chart_version-0.4.3-blue.svg?logo=helm)](https://github.com/StrangeBeeCorp/helm-charts/releases/tag/thehive-0.4.3) [![App version 5.5.10-1](https://img.shields.io/badge/App_version-5.5.10--1-blue)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
 
 Refer to [this documentation page](https://docs.strangebee.com/thehive/installation/kubernetes/) for installation instructions and configuration.


### PR DESCRIPTION
Changes summary:
- Update TheHive [from `5.5.9-1` to `5.5.10-1`](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/#5510-october-8-2025)