### PR TITLE
chore(thehive): Update TheHive to v5.6.0-1

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Nothing yet
 
+## 1.0.3
+
+- Update TheHive to v5.6.0-1 [#126](https://github.com/StrangeBeeCorp/helm-charts/pull/126)
+
 ## 1.0.2
 
 - Update TheHive to v5.5.14-2 [#125](https://github.com/StrangeBeeCorp/helm-charts/pull/125)

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 
 name: thehive
-version: 1.0.2
-appVersion: "5.5.14-2"
+version: 1.0.3
+appVersion: "5.6.0-1"
 kubeVersion: ">= 1.23.0-0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.5.14-2
+      image: strangebee/thehive:5.6.0-1
       whitelisted: true
     - name: curl
       image: curlimages/curl:8.17.0

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -2,7 +2,7 @@
 
 The official Helm Chart of TheHive for Kubernetes
 
-[![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 5.5.14-2](https://img.shields.io/badge/AppVersion-5.5.14--2-informational?style=flat-square) ](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
+[![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square)](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 5.6.0-1](https://img.shields.io/badge/AppVersion-5.6.0--1-informational?style=flat-square)](https://docs.strangebee.com/thehive/release-notes/release-notes-5.6/)
 
 ## Description
 
@@ -28,7 +28,7 @@ Kubernetes: `>= 1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.min.io | minio | 5.4.0 |
+| <https://charts.min.io> | minio | 5.4.0 |
 | oci://registry-1.docker.io/bitnamicharts | cassandra | 12.3.11 |
 | oci://registry-1.docker.io/bitnamicharts | elasticsearch | 22.1.6 |
 


### PR DESCRIPTION
- Update TheHive AppVersion and image to [v5.6.0-1](https://docs.strangebee.com/thehive/release-notes/release-notes-5.6/#560-february-2-2026)