### PR TITLE
chore: Bump TheHive chart - use image 5.7.0-1

### DIFF
--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Nothing yet
 
+## 1.0.4
+
+- Update TheHive to v5.7.0-1
+
 ## 1.0.3
 
 - Update TheHive to v5.6.0-1 [#126](https://github.com/StrangeBeeCorp/helm-charts/pull/126)

--- a/thehive-charts/thehive/CHANGELOG.md
+++ b/thehive-charts/thehive/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.4
 
-- Update TheHive to v5.7.0-1
+- Update TheHive to v5.7.0-1 [#137](https://github.com/StrangeBeeCorp/helm-charts/pull/137)
 
 ## 1.0.3
 

--- a/thehive-charts/thehive/Chart.yaml
+++ b/thehive-charts/thehive/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 
 name: thehive
-version: 1.0.3
-appVersion: "5.6.0-1"
+version: 1.0.4
+appVersion: "5.7.0-1"
 kubeVersion: ">= 1.23.0-0"
 
 dependencies:
@@ -42,7 +42,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: thehive
-      image: strangebee/thehive:5.6.0-1
+      image: strangebee/thehive:5.7.0-1
       whitelisted: true
     - name: curl
       image: curlimages/curl:8.17.0

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -2,7 +2,7 @@
 
 The official Helm Chart of TheHive for Kubernetes
 
-[![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 5.7.0-1](https://img.shields.io/badge/AppVersion-5.7.0--1-informational?style=flat-square) ](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
+[![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 5.7.0-1](https://img.shields.io/badge/AppVersion-5.7.0--1-informational?style=flat-square) ](https://docs.strangebee.com/thehive/release-notes/release-notes-5.7/)
 
 ## Description
 

--- a/thehive-charts/thehive/README.md
+++ b/thehive-charts/thehive/README.md
@@ -2,7 +2,7 @@
 
 The official Helm Chart of TheHive for Kubernetes
 
-[![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 5.6.0-1](https://img.shields.io/badge/AppVersion-5.6.0--1-informational?style=flat-square) ](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
+[![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 5.7.0-1](https://img.shields.io/badge/AppVersion-5.7.0--1-informational?style=flat-square) ](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
 
 ## Description
 

--- a/thehive-charts/thehive/README.md.gotmpl
+++ b/thehive-charts/thehive/README.md.gotmpl
@@ -2,7 +2,7 @@
 
 {{ block "chart.description" . }}{{ end }}
 
-[{{ template "chart.versionBadge" .}}](https://github.com/StrangeBeeCorp/helm-charts/releases) {{ template "chart.typeBadge" . }} [{{ template "chart.appVersionBadge" .}}](https://docs.strangebee.com/thehive/release-notes/release-notes-5.5/)
+[{{ template "chart.versionBadge" .}}](https://github.com/StrangeBeeCorp/helm-charts/releases) {{ template "chart.typeBadge" . }} [{{ template "chart.appVersionBadge" .}}](https://docs.strangebee.com/thehive/release-notes/release-notes-5.7/)
 
 ## Description
 

--- a/thehive-charts/thehive/tools/test/smoke.sh
+++ b/thehive-charts/thehive/tools/test/smoke.sh
@@ -104,6 +104,12 @@ api_call() {
     cat /tmp/response.json 2>/dev/null
     return 0
   else
+    echo "[ERROR] API call failed: ${method} ${endpoint} -> HTTP ${status_code} (expected ${expected_status})" >&2
+    local body
+    body=$(cat /tmp/response.json 2>/dev/null)
+    if [ -n "$body" ]; then
+      echo "[ERROR] Response body: ${body}" >&2
+    fi
     return 1
   fi
 }
@@ -326,6 +332,10 @@ create_alerts() {
     }' "X-Organisation: ${ORG_NAME}" > /dev/null
 
     success "Added observables to alert"
+  else
+    error "Failed to create test alert (empty or null _id returned)"
+    error "Check that '${ORG_USER}' has 'manageAlert/create' permission in '${ORG_NAME}' and that the instance license allows it"
+    exit 1
   fi
 }
 
@@ -368,6 +378,10 @@ create_case() {
     }' "X-Organisation: ${ORG_NAME}" > /dev/null
 
     success "Added observables to case"
+  else
+    error "Failed to create test case (empty or null _id returned)"
+    error "Check that '${ORG_USER}' has 'manageCase/create' permission in '${ORG_NAME}' and that the instance license allows it"
+    exit 1
   fi
 }
 
@@ -409,7 +423,8 @@ add_case_comments() {
 
 create_case_tasks() {
   if [ -z "$CASE_ID" ]; then
-    return 0
+    error "Cannot create tasks: CASE_ID is empty"
+    exit 1
   fi
 
   info "Creating tasks in case..."
@@ -437,6 +452,10 @@ create_case_tasks() {
 
   if [ -n "$TASK_ID_1" ] && [ "$TASK_ID_1" != "null" ]; then
     success "Created 3 tasks in case"
+  else
+    error "Failed to create tasks in case (empty or null _id returned)"
+    error "Check that '${ORG_USER}' has 'manageTask' permission in '${ORG_NAME}'"
+    exit 1
   fi
 }
 

--- a/thehive-charts/thehive/tools/test/smoke.sh
+++ b/thehive-charts/thehive/tools/test/smoke.sh
@@ -8,10 +8,10 @@ ORG_USER="${ORG_USER:-thehive@thehive.local}"
 ORG_PASSWORD="${ORG_PASSWORD:-thehive1234}"
 ORG_NAME="${ORG_NAME:-demo}"
 
-info()    { echo "[INFO] $1"; }
-success() { echo "[SUCCESS] $1"; }
-warning() { echo "[WARN] $1"; }
-error()   { echo "[ERROR] $1"; }
+info()    { echo "[INFO] $1" >&2; }
+success() { echo "[SUCCESS] $1" >&2; }
+warning() { echo "[WARN] $1" >&2; }
+error()   { echo "[ERROR] $1" >&2; }
 
 check_prerequisites() {
   info "Checking prerequisites..."


### PR DESCRIPTION
## Summary

- Bump `thehive` chart `1.0.3` → `1.0.4`
- Update TheHive app image `5.6.0-1` → `5.7.0-1`
- Improve `smoke.sh` test error handling