### PR TITLE
feat(cortex): Add dockerImageRegistryPrefix value

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Nothing yet
 
+## 1.2.0
+
+- Add `cortex.dockerImageRegistryPrefix` to prepend a registry prefix to every neuron Docker image at runtime (useful for pull-through caches and air-gapped clusters)
+
 ## 1.1.2
 
 - Fix init container auth env var expansion and improve error messages (401, 403, connection refused)

--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 1.2.0
 
 - Add `cortex.dockerImageRegistryPrefix` to prepend a registry prefix to every neuron Docker image at runtime (useful for pull-through caches and air-gapped clusters)
+- Bump appVersion to 4.1.0-1 (backend feature ships in Cortex 4.1.0+)
 
 ## 1.1.2
 

--- a/cortex-charts/cortex/Chart.yaml
+++ b/cortex-charts/cortex/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 
 name: cortex
 version: 1.2.0
-appVersion: "4.0.1-1"
+appVersion: "4.1.0-1"
 kubeVersion: ">= 1.23.0-0"
 
 dependencies:
@@ -35,7 +35,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/images: |
     - name: cortex
-      image: thehiveproject/cortex:4.0.0-1
+      image: thehiveproject/cortex:4.1.0-1
       whitelisted: true
     - name: curl
       image: curlimages/curl:8.17.0

--- a/cortex-charts/cortex/Chart.yaml
+++ b/cortex-charts/cortex/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 
 name: cortex
-version: 1.1.2
+version: 1.2.0
 appVersion: "4.0.1-1"
 kubeVersion: ">= 1.23.0-0"
 

--- a/cortex-charts/cortex/README.md
+++ b/cortex-charts/cortex/README.md
@@ -2,7 +2,7 @@
 
 Cortex official Helm Chart
 
-[![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 4.0.1-1](https://img.shields.io/badge/AppVersion-4.0.1--1-informational?style=flat-square) ](https://github.com/TheHive-Project/Cortex/releases)
+[![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 4.1.0-1](https://img.shields.io/badge/AppVersion-4.1.0--1-informational?style=flat-square) ](https://github.com/TheHive-Project/Cortex/releases)
 
 ## Description
 

--- a/cortex-charts/cortex/README.md
+++ b/cortex-charts/cortex/README.md
@@ -2,7 +2,7 @@
 
 Cortex official Helm Chart
 
-[![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 4.0.1-1](https://img.shields.io/badge/AppVersion-4.0.1--1-informational?style=flat-square) ](https://github.com/TheHive-Project/Cortex/releases)
+[![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ](https://github.com/StrangeBeeCorp/helm-charts/releases) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  [![AppVersion: 4.0.1-1](https://img.shields.io/badge/AppVersion-4.0.1--1-informational?style=flat-square) ](https://github.com/TheHive-Project/Cortex/releases)
 
 ## Description
 
@@ -37,6 +37,7 @@ Kubernetes: `>= 1.23.0-0`
 | cortex.affinity | object | `{}` | Affinity rules for pod assignment |
 | cortex.annotations | object | `{}` | Additional annotations to attach to Cortex resources |
 | cortex.configFile | string | `"# Cortex configuration file\n# See https://docs.strangebee.com/cortex/installation-and-configuration/#configuration-guides\nanalyzer {\n  urls: [\n    \"https://catalogs.download.strangebee.com/latest/json/analyzers.json\",\n  ]\n\n  # Customize analyzers parallelism here\n  fork-join-executor {\n    parallelism-min: 8,\n    parallelism-factor: 1.0,\n    parallelism-max: 8,\n  }\n}\n\n  # Customize responders parallelism here\nresponder {\n  urls: [\n    \"https://catalogs.download.strangebee.com/latest/json/responders.json\",\n  ]\n\n  fork-join-executor {\n    parallelism-min: 8,\n    parallelism-factor: 1.0,\n    parallelism-max: 8,\n  }\n}\n\n# ElasticSearch\nsearch {\n  # Set default value for the password\n  password = \"\"\n  # Override credentials (if these environment variables exist)\n  user = ${?CORTEX_ELASTICSEARCH_USERNAME}\n  password = ${?CORTEX_ELASTICSEARCH_PASSWORD}\n}\n\nplay.http.parser.maxDiskBuffer = 100MB\nplay.http.parser.maxMemoryBuffer = 100MB\n"` | Custom application.conf configuration file content for Cortex |
+| cortex.dockerImageRegistryPrefix | string | `""` | Registry prefix prepended to every neuron (analyzer/responder) Docker image at runtime. Useful for pull-through caches (Harbor, ECR proxy, Artifactory) and air-gapped clusters. Example: `"harbor.example.com/docker.io/"` |
 | cortex.extraCommand | list | `[]` | Extra command-line arguments for Cortex entrypoint |
 | cortex.extraEnv | list | `[]` | Extra environment variables for Cortex container |
 | cortex.httpSecret | string | `"ChangeThisSecretWithOneContainingAtLeast32Chars"` | HTTP secret for Cortex application (must be at least 32 characters) |

--- a/cortex-charts/cortex/templates/configmap-env.yaml
+++ b/cortex-charts/cortex/templates/configmap-env.yaml
@@ -19,3 +19,6 @@ data:
   {{- end }}
   job_directory: {{ .Values.cortex.jobDirectory | quote }}
   kubernetes_job_pvc: {{ include "cortex.persistentVolumeClaimName" . | quote }}
+  {{- if .Values.cortex.dockerImageRegistryPrefix }}
+  docker_image_registry_prefix: {{ .Values.cortex.dockerImageRegistryPrefix | quote }}
+  {{- end }}

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -78,6 +78,9 @@ cortex:
   # -- Directory in Cortex container used to communicate with running jobs (write inputs and read outputs)
   jobDirectory: "/tmp/cortex-jobs"
 
+  # -- Registry prefix prepended to every neuron (analyzer/responder) Docker image at runtime. Useful for pull-through caches (Harbor, ECR proxy, Artifactory) and air-gapped clusters. Example: `"harbor.example.com/docker.io/"`
+  dockerImageRegistryPrefix: ""
+
   # -- HTTP secret for Cortex application (must be at least 32 characters)
   httpSecret: "ChangeThisSecretWithOneContainingAtLeast32Chars"
   # -- Name of existing Kubernetes secret containing Cortex HTTP secret


### PR DESCRIPTION
## Summary

- Add `cortex.dockerImageRegistryPrefix` (default `""`) to expose the upstream Cortex `docker.imageRegistryPrefix` setting via the Helm chart
- Render it as a conditional `docker_image_registry_prefix` env var in `configmap-env.yaml` — the Cortex entrypoint converts it to the corresponding HOCON setting at runtime
- Bump chart version `1.1.2` → `1.2.0` (backward-compatible feature addition)
- Regenerate `README.md` via helm-docs and add a `CHANGELOG.md` entry

## Why

The upstream Cortex feature prepends a registry prefix to every neuron Docker image — useful for pull-through caches (Harbor, ECR proxy, Artifactory) and air-gapped clusters. The env-var path (matching the existing `kubernetes_job_pvc` / `job_directory` pattern) is the cleanest way to surface it; no `extraCommand` or HOCON-fragment workaround needed.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders the new conditional key only when the value is set; key absent when default (empty)
- [x] Pod env var present:
  ```
  $ kubectl exec -n cortex-test deployment/cortex -c cortex -- env | grep docker_image_registry_prefix
  docker_image_registry_prefix=private.registry.example.com/
  ```
- [x] HOCON setting written to generated Cortex config:
  ```
  $ kubectl exec -n cortex-test deployment/cortex -c cortex -- sh -c 'cat /tmp/cortex-*.conf' | grep imageRegistryPrefix
  docker.imageRegistryPrefix="private.registry.example.com/"
  ```
- [x] Default install (empty value) unchanged — no `docker_image_registry_prefix` key in ConfigMap, no behavior change for existing users

## Notes

Companion to the Cortex backend feature (already merged upstream).