### PR TITLE
feat(cortex): Add k8s jobs labels support for Neuron Jobs

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 1.2.0
 
 - Add `cortex.dockerImageRegistryPrefix` to prepend a registry prefix to every neuron Docker image at runtime (useful for pull-through caches and air-gapped clusters)
+- Add `cortex.k8sJobs.labels` to attach custom Kubernetes labels to every neuron Job/Pod (useful for ArgoCD ownership, cost allocation, and policy selectors)
 - Bump appVersion to 4.1.0-1 (backend feature ships in Cortex 4.1.0+)
 
 ## 1.1.2

--- a/cortex-charts/cortex/README.md
+++ b/cortex-charts/cortex/README.md
@@ -64,6 +64,7 @@ Kubernetes: `>= 1.23.0-0`
 | cortex.initContainers.image.tag | string | `"8.17.0"` | Init container image tag |
 | cortex.jobDirectory | string | `"/tmp/cortex-jobs"` | Directory in Cortex container used to communicate with running jobs (write inputs and read outputs) |
 | cortex.jvmOpts | string | `"-Xms2g -Xmx2g -Xmn300m"` | JVM options for Cortex application |
+| cortex.k8sJobs.labels | object | `{}` | Map of Kubernetes labels applied to every neuron Job/Pod (in addition to Cortex's built-in `cortex-job-id`, `cortex-neuron-job`, `cortex-worker-id`). Useful for ArgoCD ownership, cost allocation, and policy selectors. Example: `{"app.kubernetes.io/instance": "cortex", "app.kubernetes.io/part-of": "cortex"}` |
 | cortex.k8sSecretKey | string | `"http-secret"` | Key in the secret containing Cortex HTTP secret |
 | cortex.k8sSecretName | string | `""` | Name of existing Kubernetes secret containing Cortex HTTP secret |
 | cortex.labels | object | `{}` | Additional labels to attach to Cortex resources |

--- a/cortex-charts/cortex/templates/configmap-file.yaml
+++ b/cortex-charts/cortex/templates/configmap-file.yaml
@@ -11,7 +11,15 @@ metadata:
     {{- include "cortex.labels" . | nindent 4 }}
 data:
   {{- if .Values.cortex.configFile }}
-  application.conf: {{- .Values.cortex.configFile | toYaml | indent 1 }}
+  {{- $appConf := .Values.cortex.configFile }}
+  {{- if .Values.cortex.k8sJobs.labels }}
+    {{- $appConf = printf "%s\njob.kubernetes.labels {\n" $appConf }}
+    {{- range $k, $v := .Values.cortex.k8sJobs.labels }}
+      {{- $appConf = printf "%s  %q = %q\n" $appConf $k $v }}
+    {{- end }}
+    {{- $appConf = printf "%s}\n" $appConf }}
+  {{- end }}
+  application.conf: {{- $appConf | toYaml | indent 1 }}
   {{- end }}
   {{- if .Values.cortex.logbackXml }}
   logback.xml: {{- .Values.cortex.logbackXml | toYaml | indent 1 }}

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -81,6 +81,10 @@ cortex:
   # -- Registry prefix prepended to every neuron (analyzer/responder) Docker image at runtime. Useful for pull-through caches (Harbor, ECR proxy, Artifactory) and air-gapped clusters. Example: `"harbor.example.com/docker.io/"`
   dockerImageRegistryPrefix: ""
 
+  k8sJobs:
+    # -- Map of Kubernetes labels applied to every neuron Job/Pod (in addition to Cortex's built-in `cortex-job-id`, `cortex-neuron-job`, `cortex-worker-id`). Useful for ArgoCD ownership, cost allocation, and policy selectors. Example: `{"app.kubernetes.io/instance": "cortex", "app.kubernetes.io/part-of": "cortex"}`
+    labels: {}
+
   # -- HTTP secret for Cortex application (must be at least 32 characters)
   httpSecret: "ChangeThisSecretWithOneContainingAtLeast32Chars"
   # -- Name of existing Kubernetes secret containing Cortex HTTP secret


### PR DESCRIPTION
## Summary

- Add `cortex.k8sJobs.labels` (map, default `{}`) to attach custom Kubernetes labels to every neuron Job/Pod
- Render the labels as a HOCON `job.kubernetes.labels { … }` block appended to `application.conf` in the existing `<release>-config` ConfigMap (no env var, no entrypoint flag)
- Bump chart version `1.1.2` → `1.2.0` (backward-compatible feature)
- Regenerate `README.md` via helm-docs and add a `CHANGELOG.md` entry

## Why

The upstream Cortex feature (`K8sJobRunnerSrv.parseLabels`) reads `job.kubernetes.labels` from HOCON and stamps every neuron Job/Pod with those labels (in addition to Cortex's built-in `cortex-job-id`, `cortex-neuron-job`, `cortex-worker-id`). Useful for ArgoCD resource ownership, cost allocation, and policy selectors.

Implemented via `configFile` because the backend reads it from the loaded HOCON config — no env-var path exists.

## Test plan

```yaml
cortex:
  k8sJobs:
    labels:
      "app.kubernetes.io/instance": "cortex"
      "app.kubernetes.io/managed-by": "Helm"
      "app.kubernetes.io/part-of": "cortex"
```

- [x] `helm lint` passes
- [x] `helm template` renders the HOCON block at the tail of `application.conf` when labels are set; block absent when default (empty)
- [x] ConfigMap content:
  ```
  $ kubectl get configmap cortex-config -n cortex-test -o yaml | grep -A 5 'job.kubernetes.labels'
      job.kubernetes.labels {
        "app.kubernetes.io/instance" = "cortex"
        "app.kubernetes.io/managed-by" = "Helm"
        "app.kubernetes.io/part-of" = "cortex"
      }
  ```
- [x] Triggered a `DShield_lookup_1_0` analyzer job — resulting K8s Job carries the 3 custom labels alongside Cortex's built-in 3:
  ```
  $ kubectl get jobs -n cortex-test --show-labels
  NAME                              ... LABELS
  neuron-job-kqtdg54buz2an-qkihyz   ... app.kubernetes.io/instance=cortex,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/part-of=cortex,cortex-job-id=…,cortex-neuron-job=true,cortex-worker-id=…
  ```
- [x] Same custom labels inherited by the neuron Pod (verified with `kubectl get pod -l job-name=… -o jsonpath='{.metadata.labels}'`)
- [x] Default install (empty value) unchanged — no HOCON block, no behavior change for existing users

## Notes

Companion to the Cortex backend feature (already merged upstream).