### PR TITLE
feat(cortex): Add k8s jobs securityContext support for Neuron Jobs

### DIFF
--- a/cortex-charts/cortex/CHANGELOG.md
+++ b/cortex-charts/cortex/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `cortex.dockerImageRegistryPrefix` to prepend a registry prefix to every neuron Docker image at runtime (useful for pull-through caches and air-gapped clusters)
 - Add `cortex.k8sJobs.labels` to attach custom Kubernetes labels to every neuron Job/Pod (useful for ArgoCD ownership, cost allocation, and policy selectors)
+- Add `cortex.k8sJobs.securityContext` to set pod-level securityContext (`runAsUser`, `runAsGroup`, `fsGroup`, `runAsNonRoot`) on every neuron Job pod
 - Bump appVersion to 4.1.0-1 (backend feature ships in Cortex 4.1.0+)
 
 ## 1.1.2

--- a/cortex-charts/cortex/README.md
+++ b/cortex-charts/cortex/README.md
@@ -65,6 +65,7 @@ Kubernetes: `>= 1.23.0-0`
 | cortex.jobDirectory | string | `"/tmp/cortex-jobs"` | Directory in Cortex container used to communicate with running jobs (write inputs and read outputs) |
 | cortex.jvmOpts | string | `"-Xms2g -Xmx2g -Xmn300m"` | JVM options for Cortex application |
 | cortex.k8sJobs.labels | object | `{}` | Map of Kubernetes labels applied to every neuron Job/Pod (in addition to Cortex's built-in `cortex-job-id`, `cortex-neuron-job`, `cortex-worker-id`). Useful for ArgoCD ownership, cost allocation, and policy selectors. Example: `{"app.kubernetes.io/instance": "cortex", "app.kubernetes.io/part-of": "cortex"}` |
+| cortex.k8sJobs.securityContext | object | `{}` | Pod-level securityContext applied to every neuron Job pod. Each sub-field is optional. Make sure your analyzer/responder image accepts the user/group you set. |
 | cortex.k8sSecretKey | string | `"http-secret"` | Key in the secret containing Cortex HTTP secret |
 | cortex.k8sSecretName | string | `""` | Name of existing Kubernetes secret containing Cortex HTTP secret |
 | cortex.labels | object | `{}` | Additional labels to attach to Cortex resources |

--- a/cortex-charts/cortex/templates/configmap-file.yaml
+++ b/cortex-charts/cortex/templates/configmap-file.yaml
@@ -19,6 +19,15 @@ data:
     {{- end }}
     {{- $appConf = printf "%s}\n" $appConf }}
   {{- end }}
+  {{- $sc := .Values.cortex.k8sJobs.securityContext }}
+  {{- if or $sc.runAsUser $sc.runAsGroup $sc.fsGroup (hasKey $sc "runAsNonRoot") }}
+    {{- $appConf = printf "%s\njob.kubernetes.securityContext {\n" $appConf }}
+    {{- with $sc.runAsUser }}{{- $appConf = printf "%s  runAsUser = %v\n" $appConf . }}{{- end }}
+    {{- with $sc.runAsGroup }}{{- $appConf = printf "%s  runAsGroup = %v\n" $appConf . }}{{- end }}
+    {{- with $sc.fsGroup }}{{- $appConf = printf "%s  fsGroup = %v\n" $appConf . }}{{- end }}
+    {{- if hasKey $sc "runAsNonRoot" }}{{- $appConf = printf "%s  runAsNonRoot = %v\n" $appConf $sc.runAsNonRoot }}{{- end }}
+    {{- $appConf = printf "%s}\n" $appConf }}
+  {{- end }}
   application.conf: {{- $appConf | toYaml | indent 1 }}
   {{- end }}
   {{- if .Values.cortex.logbackXml }}

--- a/cortex-charts/cortex/values.yaml
+++ b/cortex-charts/cortex/values.yaml
@@ -84,6 +84,12 @@ cortex:
   k8sJobs:
     # -- Map of Kubernetes labels applied to every neuron Job/Pod (in addition to Cortex's built-in `cortex-job-id`, `cortex-neuron-job`, `cortex-worker-id`). Useful for ArgoCD ownership, cost allocation, and policy selectors. Example: `{"app.kubernetes.io/instance": "cortex", "app.kubernetes.io/part-of": "cortex"}`
     labels: {}
+    # -- Pod-level securityContext applied to every neuron Job pod. Each sub-field is optional. Make sure your analyzer/responder image accepts the user/group you set.
+    securityContext: {}
+      # runAsUser: 1000
+      # runAsGroup: 1000
+      # fsGroup: 1000
+      # runAsNonRoot: false
 
   # -- HTTP secret for Cortex application (must be at least 32 characters)
   httpSecret: "ChangeThisSecretWithOneContainingAtLeast32Chars"


### PR DESCRIPTION
## Summary

- Add `cortex.k8sJobs.securityContext` (object, default `{}`) to set pod-level securityContext on every neuron Job pod
- Supports the 4 fields the upstream backend understands: `runAsUser` (int), `runAsGroup` (int), `fsGroup` (int), `runAsNonRoot` (bool) — all optional, only set fields are emitted
- Render the values as a HOCON `job.kubernetes.securityContext { … }` block appended to `application.conf` in the existing `<release>-config` ConfigMap (no env var, no entrypoint flag)
- Bump chart version `1.1.2` → `1.2.0` (backward-compatible feature)
- Regenerate `README.md` via helm-docs and add a `CHANGELOG.md` entry

## Why

The upstream Cortex feature (`K8sJobRunnerSrv.parsePodSecurityContext`) reads `job.kubernetes.securityContext` from HOCON and stamps every neuron Job pod with the corresponding pod-level securityContext. Useful for cluster security policies (PodSecurityStandards), mounted-volume permissions via `fsGroup`, and non-root enforcement.

Implemented via `configFile` because the backend reads it from HOCON — no env-var path exists.

## Test plan

Verified live on `eks-lab` (eu-west-3) with the Cortex develop image `897729131019.dkr.ecr.eu-west-3.amazonaws.com/cortex:4.0.1-1-develop` and `cortex.k8sJobs.securityContext.fsGroup: 1000`:

- [x] `helm lint` passes
- [x] `helm template` renders the HOCON block per-field. Verified 3 scenarios:
  - `fsGroup` only → only `fsGroup = 1000` emitted
  - All four with `runAsNonRoot: false` → `false` preserved (proves `hasKey` path)
  - Default empty → no HOCON block, no behavior change for existing installs
- [x] ConfigMap content:
  ```
  $ kubectl get configmap cortex-config -n cortex-test -o yaml | grep -A 3 'job.kubernetes.securityContext'
      job.kubernetes.securityContext {
        fsGroup = 1000
      }
  ```
- [x] Triggered a `DShield_lookup_1_0` analyzer job — resulting neuron Pod carries the expected pod-level securityContext:
  ```
  $ kubectl get pod <neuron-job-…> -o jsonpath='{.spec.securityContext}'
  {"fsGroup":1000}
  ```
- [x] Container-level securityContext stays empty (pod-level only, as designed)

## Notes

Companion to the Cortex backend feature (already merged upstream).